### PR TITLE
Extend diary model

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -33,7 +33,7 @@ function App() {
 
   // Click "New Entry" resets the editor
   const handleNew = () => {
-    setSelectedEntry({ content: '' });
+    setSelectedEntry({ text: '' });
   };
 
   return (

--- a/lune-interface/client/src/components/DiaryEditable.js
+++ b/lune-interface/client/src/components/DiaryEditable.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 
 function DiaryEditable({ entry, onSave }) {
-  const [content, setContent] = useState('');
+  const [text, setText] = useState('');
 
   // Load content when entry changes
   useEffect(() => {
-    setContent(entry && entry.content ? entry.content : '');
+    setText(entry && entry.text ? entry.text : '');
   }, [entry]);
 
   // Guard for no entry selected
@@ -20,28 +20,24 @@ function DiaryEditable({ entry, onSave }) {
   // Handle form submit (save new or updated entry)
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!content.trim()) return;
+    if (!text.trim()) return;
     try {
       if (entry._id) {
-        // Edit existing
         await fetch(`/diary/${entry._id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content }),
+          body: JSON.stringify({ text }),
         });
       } else {
-        // Create new
-        console.log('Trying to POST content:', content);
         await fetch('/diary', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content }),
+          body: JSON.stringify({ text }),
         });
       }
-      setContent('');
+      setText('');
       onSave && onSave();
     } catch (err) {
-      // Optionally handle fetch error here
       console.error('Failed to save entry:', err);
     }
   };
@@ -49,11 +45,11 @@ function DiaryEditable({ entry, onSave }) {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-2">
       <textarea
-        id="diary-content"
-        name="content"
+        id="diary-text"
+        name="text"
         className="w-full border rounded p-2 mb-2 min-h-[120px]"
-        value={content}
-        onChange={e => setContent(e.target.value)}
+        value={text}
+        onChange={e => setText(e.target.value)}
         placeholder="Write your thoughts..."
         required
       />

--- a/lune-interface/client/src/components/EntriesMenu.js
+++ b/lune-interface/client/src/components/EntriesMenu.js
@@ -5,7 +5,7 @@ function EntriesMenu({ entries, onSelect, onNew }) {
 
   // Filter entries by search term
   const filtered = (Array.isArray(entries) ? entries : []).filter(e =>
-    (e.content || e.text || '').toLowerCase().includes(search.toLowerCase())
+    (e.text || '').toLowerCase().includes(search.toLowerCase())
   );
 
   return (
@@ -37,12 +37,12 @@ function EntriesMenu({ entries, onSelect, onNew }) {
             role="button"
             onClick={() => onSelect(entry)}
             onKeyPress={e => (e.key === 'Enter' || e.key === ' ') && onSelect(entry)}
-            aria-label={`Select diary entry from ${entry.createdAt ? new Date(entry.createdAt).toLocaleDateString() : 'Unknown date'}`}
+            aria-label={`Select diary entry from ${entry.timestamp ? new Date(entry.timestamp).toLocaleDateString() : 'Unknown date'}`}
           >
             <div className="text-xs text-luneDarkGray">
-              {entry.createdAt ? new Date(entry.createdAt).toLocaleString() : 'No Date'}
+              {entry.timestamp ? new Date(entry.timestamp).toLocaleString() : 'No Date'}
             </div>
-            <div className="truncate">{entry.content || entry.text || '[No Content]'}</div>
+            <div className="truncate">{entry.text || '[No Content]'}</div>
           </div>
         ))}
         {filtered.length === 0 && (

--- a/lune-interface/server/models/DiaryEntry.js
+++ b/lune-interface/server/models/DiaryEntry.js
@@ -1,8 +1,31 @@
 const mongoose = require('mongoose');
 
 const DiaryEntrySchema = new mongoose.Schema({
-  content: { type: String, required: true },
-  createdAt: { type: Date, default: Date.now }
-});
+  type: { type: String, default: 'DiaryEntry' },
+  text: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now },
+  fields: { type: [String], default: [] },
+  states: { type: [String], default: [] },
+  loops: { type: [String], default: [] },
+  links: { type: [String], default: [] },
+  agent_logs: {
+    Resistor: {
+      text: String,
+      references: [String]
+    },
+    Interpreter: {
+      text: String,
+      references: [String]
+    },
+    Forge: {
+      text: String,
+      references: [String]
+    },
+    Lune: {
+      text: String,
+      references: [String]
+    }
+  }
+}, { minimize: false });
 
 module.exports = mongoose.model('DiaryEntry', DiaryEntrySchema);

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -2,14 +2,14 @@ const express = require('express');
 const router = express.Router();
 const DiaryEntry = require('../models/DiaryEntry');
 
-// Create a diary entry (accepts 'content' or old 'text')
+// Create a diary entry (accepts 'text' or legacy 'content')
 router.post('/', async (req, res) => {
   try {
-    const content = req.body.content || req.body.text;
-    if (!content || typeof content !== 'string') {
-      return res.status(400).json({ error: 'Content is required.' });
+    const text = req.body.text || req.body.content;
+    if (!text || typeof text !== 'string') {
+      return res.status(400).json({ error: 'Text is required.' });
     }
-    const entry = new DiaryEntry({ content });
+    const entry = new DiaryEntry({ text });
     await entry.save();
     res.status(201).json(entry);
   } catch (err) {
@@ -20,7 +20,7 @@ router.post('/', async (req, res) => {
 // Get all entries (newest first)
 router.get('/', async (req, res) => {
   try {
-    const entries = await DiaryEntry.find().sort({ createdAt: -1 });
+    const entries = await DiaryEntry.find().sort({ timestamp: -1 });
     res.json(entries);
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -30,13 +30,13 @@ router.get('/', async (req, res) => {
 // Edit an entry (update content and refresh date)
 router.put('/:id', async (req, res) => {
   try {
-    const content = req.body.content;
-    if (!content || typeof content !== 'string') {
-      return res.status(400).json({ error: 'Content is required.' });
+    const text = req.body.text;
+    if (!text || typeof text !== 'string') {
+      return res.status(400).json({ error: 'Text is required.' });
     }
     const entry = await DiaryEntry.findByIdAndUpdate(
       req.params.id,
-      { content, createdAt: new Date() },
+      { text, timestamp: new Date() },
       { new: true }
     );
     if (!entry) return res.status(404).json({ error: 'Entry not found.' });


### PR DESCRIPTION
## Summary
- expand diary schema with fields to hold text, timestamps, references and logs
- adjust diary routes to use new schema
- update React components to edit `text` field

## Testing
- `npm test --prefix lune-interface/client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f906859f083278c9ee4b4ae8ee30f