### PR TITLE
Fix Lune chat path

### DIFF
--- a/lune-interface/client/src/App.test.js
+++ b/lune-interface/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders diary heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText(/lune diary/i);
+  expect(headingElement).toBeInTheDocument();
 });

--- a/lune-interface/client/src/components/LuneChatModal.js
+++ b/lune-interface/client/src/components/LuneChatModal.js
@@ -16,7 +16,7 @@ export default function LuneChatModal({ open, onClose, entries }) {
     setLoading(true);
 
     try {
-      const res = await fetch('/lune/send', {
+      const res = await fetch('/api/lune/send', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
- connect LuneChatModal to correct `/api/lune/send` endpoint
- update test to check for `Lune Diary`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f96554624832783e91b746e3cd313