### PR TITLE
Implement agent processing workflow

### DIFF
--- a/lune-interface/client/src/components/DiaryEditable.js
+++ b/lune-interface/client/src/components/DiaryEditable.js
@@ -59,6 +59,17 @@ function DiaryEditable({ entry, onSave }) {
       >
         Save Entry
       </button>
+
+      {entry.agent_logs && (
+        <div className="mt-4 space-y-2">
+          {Object.entries(entry.agent_logs).map(([agent, log]) => (
+            <div key={agent} className="border rounded p-2 bg-luneGray/20">
+              <h3 className="font-semibold text-sm mb-1">{agent}</h3>
+              <div className="text-sm whitespace-pre-wrap">{log.text}</div>
+            </div>
+          ))}
+        </div>
+      )}
     </form>
   );
 }

--- a/lune-interface/server/controllers/forge.js
+++ b/lune-interface/server/controllers/forge.js
@@ -1,0 +1,13 @@
+const DiaryEntry = require('../models/DiaryEntry');
+
+exports.processEntry = async function(entry) {
+  entry.agent_logs = entry.agent_logs || {};
+  const interp = entry.agent_logs.Interpreter ? entry.agent_logs.Interpreter.text : '';
+  const summary = entry.text ? entry.text.slice(0, 60) : '';
+  entry.agent_logs.Forge = {
+    text: `Summary: ${summary}... | Interpreter says: ${interp}`,
+    references: []
+  };
+  entry.markModified('agent_logs');
+  await entry.save();
+};

--- a/lune-interface/server/controllers/interpreter.js
+++ b/lune-interface/server/controllers/interpreter.js
@@ -1,0 +1,13 @@
+const DiaryEntry = require('../models/DiaryEntry');
+
+exports.processEntry = async function(entry) {
+  entry.agent_logs = entry.agent_logs || {};
+  const wordCount = entry.text ? entry.text.trim().split(/\s+/).length : 0;
+  const previous = entry.agent_logs.Resistor ? entry.agent_logs.Resistor.text : '';
+  entry.agent_logs.Interpreter = {
+    text: `Word count: ${wordCount}. Prior analysis: ${previous}`,
+    references: []
+  };
+  entry.markModified('agent_logs');
+  await entry.save();
+};

--- a/lune-interface/server/controllers/resistor.js
+++ b/lune-interface/server/controllers/resistor.js
@@ -1,0 +1,27 @@
+const DiaryEntry = require('../models/DiaryEntry');
+
+// Simple sentiment-like analysis. Counts some positive/negative words.
+const positiveWords = ['happy','joy','excited','good','great'];
+const negativeWords = ['sad','angry','upset','bad','terrible'];
+
+function scoreSentiment(text) {
+  if (!text) return 0;
+  const words = text.toLowerCase().split(/\W+/);
+  let score = 0;
+  for (const w of words) {
+    if (positiveWords.includes(w)) score += 1;
+    if (negativeWords.includes(w)) score -= 1;
+  }
+  return score;
+}
+
+exports.processEntry = async function(entry) {
+  const score = scoreSentiment(entry.text);
+  entry.agent_logs = entry.agent_logs || {};
+  entry.agent_logs.Resistor = {
+    text: `Sentiment score: ${score}`,
+    references: []
+  };
+  entry.markModified('agent_logs');
+  await entry.save();
+};

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const DiaryEntry = require('../models/DiaryEntry');
+const resistor = require('../controllers/resistor');
+const interpreter = require('../controllers/interpreter');
+const forge = require('../controllers/forge');
 
 // Create a diary entry (accepts 'text' or legacy 'content')
 router.post('/', async (req, res) => {
@@ -11,6 +14,16 @@ router.post('/', async (req, res) => {
     }
     const entry = new DiaryEntry({ text });
     await entry.save();
+
+    // Trigger simple agent processing sequentially
+    try {
+      await resistor.processEntry(entry);
+      await interpreter.processEntry(entry);
+      await forge.processEntry(entry);
+    } catch (err) {
+      console.error('Agent processing failed:', err);
+    }
+
     res.status(201).json(entry);
   } catch (err) {
     res.status(400).json({ error: err.message });


### PR DESCRIPTION
## Summary
- add Resistor, Interpreter and Forge controllers
- run all three agents when a diary entry is created
- show agent output when viewing an entry

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_683f9e91081083279ec118989bf84c56