### PR TITLE
Add key application flow doc

### DIFF
--- a/docs/key_application_flow.md
+++ b/docs/key_application_flow.md
@@ -1,0 +1,10 @@
+# Key Application Flow
+
+This document outlines the current flow for diary entries and agent processing.
+
+1. **User entry** – Diary entries are written in the React component `DiaryEditable`.
+2. **Backend submission** – Entries are posted to the backend where they are handled by the controller `server/controllers/lune.js` and stored using the `DiaryEntry` model.
+3. **Agent processing** – Agents like **Lune** (and future helpers) can read or manipulate saved entries through these controllers and models.
+4. **Context management** – All contextual data flows through the existing models such as `DiaryEntry.js`, allowing expansion into features like the Knowledge Dock or additional agent pipelines.
+
+The intent is to keep the pipeline modular so future agents can reference and update `DiaryEntry` documents or derived outputs while maintaining history.


### PR DESCRIPTION
## Summary
- document the diary entry workflow in `docs/key_application_flow.md`

## Testing
- `npm install --silent` in `client`
- `CI=true npm test --silent --max-workers=2`

------
https://chatgpt.com/codex/tasks/task_e_683f9e66e49083278c7cc8761847e2e0