### PR TITLE
Implement agent pipeline and tag parsing

### DIFF
--- a/docs/key_application_flow.md
+++ b/docs/key_application_flow.md
@@ -4,7 +4,8 @@ This document outlines the current flow for diary entries and agent processing.
 
 1. **User entry** – Diary entries are written in the React component `DiaryEditable`.
 2. **Backend submission** – Entries are posted to the backend where they are handled by the controller and written to `server/diary.json` via the file-based store `diaryStore.js`.
-3. **Agent processing** – Agents like **Lune** (and future helpers) operate directly on this JSON file, updating their logs in place for each entry.
+   The store extracts any `[[tags]]` from the text and categorizes them into fields, states or loops.
+3. **Agent processing** – A chain of agents (Resistor → Interpreter → Forge → Lune) operates directly on `diary.json`. Each agent reads the entry and previous logs, writes its own output under `agent_logs`, and never alters other data.
 4. **Context management** – All contextual data flows through `diaryStore.js`, allowing expansion into features like the Knowledge Dock or additional agent pipelines without using a database.
 
 The intent is to keep the pipeline modular so future agents can reference and update diary entries or derived outputs while maintaining history.

--- a/lune-interface/server/controllers/forge.js
+++ b/lune-interface/server/controllers/forge.js
@@ -6,7 +6,7 @@ exports.processEntry = async function(entry) {
   const summary = entry.text ? entry.text.slice(0, 60) : '';
   entry.agent_logs.Forge = {
     text: `Summary: ${summary}... | Interpreter says: ${interp}`,
-    references: []
+    references: ['Resistor', 'Interpreter', 'fields', 'loops']
   };
   await diaryStore.saveEntry(entry);
 };

--- a/lune-interface/server/controllers/interpreter.js
+++ b/lune-interface/server/controllers/interpreter.js
@@ -6,7 +6,7 @@ exports.processEntry = async function(entry) {
   const previous = entry.agent_logs.Resistor ? entry.agent_logs.Resistor.text : '';
   entry.agent_logs.Interpreter = {
     text: `Word count: ${wordCount}. Prior analysis: ${previous}`,
-    references: []
+    references: ['text', 'Resistor']
   };
   await diaryStore.saveEntry(entry);
 };

--- a/lune-interface/server/controllers/lune.js
+++ b/lune-interface/server/controllers/lune.js
@@ -40,3 +40,19 @@ exports.handleUserMessage = async (req, res) => {
     res.status(500).json({ error: "Lune failed to reply." });
   }
 };
+
+// Lightweight offline reflection for diary pipeline
+const diaryStore = require('../diaryStore');
+
+exports.processEntry = async function(entry) {
+  entry.agent_logs = entry.agent_logs || {};
+  const resOut = entry.agent_logs.Resistor ? entry.agent_logs.Resistor.text : '';
+  const interpOut = entry.agent_logs.Interpreter ? entry.agent_logs.Interpreter.text : '';
+  const forgeOut = entry.agent_logs.Forge ? entry.agent_logs.Forge.text : '';
+  const reflection = `Based on your entry and analyses: ${resOut}; ${interpOut}; ${forgeOut}`;
+  entry.agent_logs.Lune = {
+    text: reflection,
+    references: ['text', 'Resistor', 'Interpreter', 'Forge']
+  };
+  await diaryStore.saveEntry(entry);
+};

--- a/lune-interface/server/controllers/resistor.js
+++ b/lune-interface/server/controllers/resistor.js
@@ -20,7 +20,7 @@ exports.processEntry = async function(entry) {
   entry.agent_logs = entry.agent_logs || {};
   entry.agent_logs.Resistor = {
     text: `Sentiment score: ${score}`,
-    references: []
+    references: ['text']
   };
   await diaryStore.saveEntry(entry);
 };

--- a/lune-interface/server/diaryStore.js
+++ b/lune-interface/server/diaryStore.js
@@ -30,14 +30,40 @@ exports.getAll = async function() {
   return diary.slice().sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
 };
 
+function parseTags(text) {
+  const fields = new Set();
+  const states = new Set();
+  const loops = new Set();
+  if (typeof text === 'string') {
+    const regex = /\[\[([^\[]+?)\]\]/g;
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const tag = `[[${match[1]}]]`;
+      if (/loop/i.test(match[1])) {
+        loops.add(tag);
+      } else if (/state/i.test(match[1])) {
+        states.add(tag);
+      } else {
+        fields.add(tag);
+      }
+    }
+  }
+  return {
+    fields: Array.from(fields),
+    states: Array.from(states),
+    loops: Array.from(loops)
+  };
+}
+
 exports.add = async function(text) {
+  const tags = parseTags(text);
   const entry = {
     id: crypto.randomUUID(),
     text,
     timestamp: new Date().toISOString(),
-    fields: [],
-    states: [],
-    loops: [],
+    fields: tags.fields,
+    states: tags.states,
+    loops: tags.loops,
     links: [],
     agent_logs: {}
   };

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -4,6 +4,7 @@ const diaryStore = require('../diaryStore');
 const resistor = require('../controllers/resistor');
 const interpreter = require('../controllers/interpreter');
 const forge = require('../controllers/forge');
+const lune = require('../controllers/lune');
 
 // Create a diary entry (accepts 'text' or legacy 'content')
 router.post('/', async (req, res) => {
@@ -19,6 +20,7 @@ router.post('/', async (req, res) => {
       await resistor.processEntry(entry);
       await interpreter.processEntry(entry);
       await forge.processEntry(entry);
+      await lune.processEntry(entry);
     } catch (err) {
       console.error('Agent processing failed:', err);
     }


### PR DESCRIPTION
## Summary
- extract `[[tags]]` in `diaryStore.add` and categorize into fields, states, or loops
- add references for Resistor, Interpreter, and Forge logs
- create a `processEntry` helper in `lune.js` for automated reflections
- invoke Resistor, Interpreter, Forge, and Lune sequentially when creating a diary entry
- document agent chain in `key_application_flow.md`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_683fa76d81a08327b2fc7acac8f02513