### PR TITLE
Add DockChat and entries page

### DIFF
--- a/lune-interface/client/package-lock.json
+++ b/lune-interface/client/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       },
@@ -3090,6 +3091,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -13946,6 +13956,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/lune-interface/client/package.json
+++ b/lune-interface/client/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^6.30.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
@@ -42,5 +43,4 @@
     "tailwindcss": "^3.4.3"
   },
   "proxy": "http://localhost:5001"
-
 }

--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -1,12 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import EntriesMenu from './components/EntriesMenu';
-import DiaryEditable from './components/DiaryEditable';
-import LuneChatModal from './components/LuneChatModal'; // <-- NEW IMPORT
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import DockChat from './components/DockChat';
+import EntriesPage from './components/EntriesPage';
 
 function App() {
   const [entries, setEntries] = useState([]);
-  const [selectedEntry, setSelectedEntry] = useState(null);
-  const [luneOpen, setLuneOpen] = useState(false); // <-- NEW STATE
+  const [editingId, setEditingId] = useState(null);
 
   // Fetch entries from backend
   const fetchEntries = async () => {
@@ -20,55 +19,24 @@ function App() {
     fetchEntries();
   }, []);
 
-  // Refresh entries after save
-  const handleSave = async () => {
+  const refreshEntries = async () => {
     await fetchEntries();
-    setSelectedEntry(null); // Clear selection after save
-  };
-
-  // Select entry to edit
-  const handleSelect = (entry) => {
-    setSelectedEntry(entry);
-  };
-
-  // Click "New Entry" resets the editor
-  const handleNew = () => {
-    setSelectedEntry({ text: '' });
   };
 
   return (
-    <div className="min-h-screen bg-luneGray p-4">
-      <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center">Lune Diary</h1>
-      {/* Lune Chat Button and Modal */}
-      <button
-        className="bg-lunePurple text-white px-4 py-2 rounded mb-4"
-        onClick={() => setLuneOpen(true)}
-      >
-        Chat with Lune
-      </button>
-      <LuneChatModal
-        open={luneOpen}
-        onClose={() => setLuneOpen(false)}
-        entries={entries}
-      />
-      <div className="max-w-3xl mx-auto flex flex-col md:flex-row gap-6">
-        {/* Left panel: EntriesMenu */}
-        <div className="w-full md:w-1/2">
-          <EntriesMenu
-            entries={entries}
-            onSelect={handleSelect}
-            onNew={handleNew}
-          />
-        </div>
-        {/* Right panel: DiaryEditable */}
-        <div className="w-full md:w-1/2">
-          <DiaryEditable
-            entry={selectedEntry}
-            onSave={handleSave}
-          />
-        </div>
-      </div>
-    </div>
+    <Router>
+      <Routes>
+        <Route
+          path="/chat"
+          element={<DockChat entries={entries} refreshEntries={refreshEntries} editingId={editingId} setEditingId={setEditingId} />}
+        />
+        <Route
+          path="/entries"
+          element={<EntriesPage entries={entries} refreshEntries={refreshEntries} startEdit={setEditingId} />}
+        />
+        <Route path="*" element={<Navigate to="/chat" replace />} />
+      </Routes>
+    </Router>
   );
 }
 

--- a/lune-interface/client/src/App.test.js
+++ b/lune-interface/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders diary heading', () => {
+test('renders dock chat heading', () => {
   render(<App />);
-  const headingElement = screen.getByText(/lune diary/i);
+  const headingElement = screen.getByText(/dock chat/i);
   expect(headingElement).toBeInTheDocument();
 });

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -1,0 +1,75 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function DockChat({ entries, refreshEntries, editingId, setEditingId }) {
+  const [input, setInput] = useState('');
+  const [editing, setEditing] = useState(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const id = editingId ?? editing;
+    if (id) {
+      const entry = entries.find(e => e.id === id);
+      setInput(entry ? entry.text : '');
+      setEditing(id);
+      if (setEditingId) setEditingId(null);
+    }
+  }, [editingId, editing, entries, setEditingId]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    try {
+      if (editing) {
+        await fetch(`/diary/${editing}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: input })
+        });
+      } else {
+        await fetch('/diary', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: input })
+        });
+      }
+      setInput('');
+      setEditing(null);
+      await refreshEntries();
+    } catch (err) {
+      console.error('Failed to save entry', err);
+    }
+  };
+
+  const startEdit = (id) => setEditing(id);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center">Dock Chat</h1>
+      <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto">
+        {entries.slice().sort((a,b) => new Date(a.timestamp) - new Date(b.timestamp)).map(entry => (
+          <div key={entry.id} className="bg-white p-3 rounded shadow">
+            <div className="text-xs text-luneDarkGray">{new Date(entry.timestamp).toLocaleString()}</div>
+            <div className="whitespace-pre-wrap">{entry.text}</div>
+            {entry.agent_logs?.Lune && (
+              <div className="mt-2 p-2 bg-luneGray rounded">
+                <span className="font-semibold">Lune:</span> {entry.agent_logs.Lune.text}
+              </div>
+            )}
+            <button onClick={() => startEdit(entry.id)} className="text-sm text-lunePurple mt-1">Edit</button>
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="flex gap-2">
+        <textarea
+          className="flex-1 border rounded p-2"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Write your thoughts..."
+        />
+        <button type="submit" className="bg-luneGreen text-white px-4 py-2 rounded">{editing ? 'Update' : 'Add'}</button>
+      </form>
+      <button onClick={() => navigate('/entries')} className="mt-4 text-lunePurple underline">Go to Entries</button>
+    </div>
+  );
+}

--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function EntriesPage({ entries, refreshEntries, startEdit }) {
+  const navigate = useNavigate();
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this entry?')) return;
+    await fetch(`/diary/${id}`, { method: 'DELETE' });
+    await refreshEntries();
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center">Entries</h1>
+      <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto">
+        {entries.map(entry => (
+          <div key={entry.id} className="bg-white p-3 rounded shadow">
+            <div className="text-xs text-luneDarkGray">{new Date(entry.timestamp).toLocaleString()}</div>
+            <div className="whitespace-pre-wrap mb-2">{entry.text}</div>
+            {entry.agent_logs?.Lune && (
+              <div className="mb-2 p-2 bg-luneGray rounded">
+                <span className="font-semibold">Lune:</span> {entry.agent_logs.Lune.text}
+              </div>
+            )}
+            <button onClick={() => { startEdit(entry.id); navigate('/chat'); }} className="text-sm text-lunePurple mr-2">Edit</button>
+            <button onClick={() => handleDelete(entry.id)} className="text-sm text-red-600">Delete</button>
+          </div>
+        ))}
+        {entries.length === 0 && <div className="text-center text-luneDarkGray">No entries.</div>}
+      </div>
+      <button onClick={() => navigate('/chat')} className="text-lunePurple underline">Back to Chat</button>
+    </div>
+  );
+}

--- a/lune-interface/server/diaryStore.js
+++ b/lune-interface/server/diaryStore.js
@@ -93,3 +93,13 @@ exports.saveEntry = async function(entry) {
   }
   return entry;
 };
+
+exports.remove = async function(id) {
+  const index = diary.findIndex(e => e.id === id);
+  if (index !== -1) {
+    diary.splice(index, 1);
+    save();
+    return true;
+  }
+  return false;
+};

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -50,7 +50,26 @@ router.put('/:id', async (req, res) => {
     }
     const entry = await diaryStore.updateText(req.params.id, text);
     if (!entry) return res.status(404).json({ error: 'Entry not found.' });
+    try {
+      await resistor.processEntry(entry);
+      await interpreter.processEntry(entry);
+      await forge.processEntry(entry);
+      await lune.processEntry(entry);
+    } catch (err) {
+      console.error('Agent processing failed:', err);
+    }
     res.json(entry);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Delete an entry
+router.delete('/:id', async (req, res) => {
+  try {
+    const success = await diaryStore.remove(req.params.id);
+    if (!success) return res.status(404).json({ error: 'Entry not found.' });
+    res.json({ message: 'Deleted' });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- add DockChat page and Entries list page
- integrate React Router
- support editing and deleting diary entries
- refresh Lune agent reflection when entries are edited
- update tests

## Testing
- `npm test --silent`
- `npm test` in `lune-interface/server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683faad975888327a3e4e6aaa98b94fb