### PR TITLE
Use reflection field for Lune logs

### DIFF
--- a/docs/key_application_flow.md
+++ b/docs/key_application_flow.md
@@ -5,7 +5,7 @@ This document outlines the current flow for diary entries and agent processing.
 1. **User entry** – Diary entries are written in the React component `DiaryEditable`.
 2. **Backend submission** – Entries are posted to the backend where they are handled by the controller and written to `server/diary.json` via the file-based store `diaryStore.js`.
    The store extracts any `[[tags]]` from the text and categorizes them into fields, states or loops.
-3. **Agent processing** – A chain of agents (Resistor → Interpreter → Forge → Lune) operates directly on `diary.json`. Each agent reads the entry and previous logs, writes its own output under `agent_logs`, and never alters other data.
+3. **Agent processing** – A chain of agents (Resistor → Interpreter → Forge → Lune) operates directly on `diary.json`. Each agent reads the entry and previous logs, writing its own output under `agent_logs`. Lune stores its response in `agent_logs.Lune.reflection`.
 4. **Context management** – All contextual data flows through `diaryStore.js`, allowing expansion into features like the Knowledge Dock or additional agent pipelines without using a database.
 
 The intent is to keep the pipeline modular so future agents can reference and update diary entries or derived outputs while maintaining history.

--- a/lune-interface/client/src/components/DiaryEditable.js
+++ b/lune-interface/client/src/components/DiaryEditable.js
@@ -65,7 +65,7 @@ function DiaryEditable({ entry, onSave }) {
           {Object.entries(entry.agent_logs).map(([agent, log]) => (
             <div key={agent} className="border rounded p-2 bg-luneGray/20">
               <h3 className="font-semibold text-sm mb-1">{agent}</h3>
-              <div className="text-sm whitespace-pre-wrap">{log.text}</div>
+              <div className="text-sm whitespace-pre-wrap">{log.reflection || log.text}</div>
             </div>
           ))}
         </div>

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -53,7 +53,7 @@ export default function DockChat({ entries, refreshEntries, editingId, setEditin
             <div className="whitespace-pre-wrap">{entry.text}</div>
             {entry.agent_logs?.Lune && (
               <div className="mt-2 p-2 bg-luneGray rounded">
-                <span className="font-semibold">Lune:</span> {entry.agent_logs.Lune.text}
+                <span className="font-semibold">Lune:</span> {entry.agent_logs.Lune.reflection}
               </div>
             )}
             <button onClick={() => startEdit(entry.id)} className="text-sm text-lunePurple mt-1">Edit</button>

--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -20,7 +20,7 @@ export default function EntriesPage({ entries, refreshEntries, startEdit }) {
             <div className="whitespace-pre-wrap mb-2">{entry.text}</div>
             {entry.agent_logs?.Lune && (
               <div className="mb-2 p-2 bg-luneGray rounded">
-                <span className="font-semibold">Lune:</span> {entry.agent_logs.Lune.text}
+                <span className="font-semibold">Lune:</span> {entry.agent_logs.Lune.reflection}
               </div>
             )}
             <button onClick={() => { startEdit(entry.id); navigate('/chat'); }} className="text-sm text-lunePurple mr-2">Edit</button>

--- a/lune-interface/server/controllers/lune.js
+++ b/lune-interface/server/controllers/lune.js
@@ -51,7 +51,7 @@ exports.processEntry = async function(entry) {
   const forgeOut = entry.agent_logs.Forge ? entry.agent_logs.Forge.text : '';
   const reflection = `Based on your entry and analyses: ${resOut}; ${interpOut}; ${forgeOut}`;
   entry.agent_logs.Lune = {
-    text: reflection,
+    reflection,
     references: ['text', 'Resistor', 'Interpreter', 'Forge']
   };
   await diaryStore.saveEntry(entry);

--- a/lune-interface/server/models/DiaryEntry.js
+++ b/lune-interface/server/models/DiaryEntry.js
@@ -22,7 +22,7 @@ const DiaryEntrySchema = new mongoose.Schema({
       references: [String]
     },
     Lune: {
-      text: String,
+      reflection: String,
       references: [String]
     }
   }


### PR DESCRIPTION
## Summary
- rename `agent_logs.Lune.text` field to `agent_logs.Lune.reflection`
- display the new field in DockChat, EntriesPage and DiaryEditable
- document the reflection field in `key_application_flow.md`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fad8c38688327bf6f7871daa36370