### PR TITLE
Improve offline diary features

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ This repository includes a minimal diary application located in `offline-diary/`
 The app works entirely in the browser using the File System Access API so it can
 function offline without a backend server or agent.
 
-## Usage
+## Browser Support
 
+This app requires a browser with File System Access API support, such as Chrome or Edge, running in a secure context (HTTPS or localhost).
+
+## Usage
 1. Open `offline-diary/index.html` in a modern browser (e.g. Chrome).
-2. Click **Open Diary** to select an existing `diary.json` file or **Create Diary** to
-   make a new one.
+2. Click **Open Diary** to select an existing `diary.json` file or **Create Diary** to make a new one.
 3. Write entries in the text box and click **Save Entry**.
-4. Existing entries appear below with Edit and Delete options. All changes are
-   saved directly to `diary.json`.
+4. Existing entries appear below with Edit and Delete options. All changes are saved directly to `diary.json`.
+5. Use the search box to filter entries.
+6. Your draft text is automatically saved locally until you save the entry.
+7. Enter a password before opening or creating a diary to encrypt the file.
+8. Use **Export** to download a CSV copy and **Import** to merge entries from another JSON file.
 
 Entries are stored as an array of objects with `id`, `text` and `timestamp`.

--- a/offline-diary/index.html
+++ b/offline-diary/index.html
@@ -10,9 +10,14 @@
   <div class="container">
     <h1>Offline Diary</h1>
     <div id="file-buttons">
+      <input id="passwordInput" type="password" placeholder="Password (optional)">
       <button id="openFile">Open Diary</button>
       <button id="createFile">Create Diary</button>
+      <button id="exportBtn" disabled>Export CSV</button>
+      <button id="importBtn">Import JSON</button>
+      <input id="importInput" type="file" accept=".json" style="display:none">
     </div>
+    <input id="searchInput" placeholder="Search entries..." disabled>
     <textarea id="entryInput" placeholder="Write a new entry..." rows="4" disabled></textarea>
     <button id="saveEntry" disabled>Save Entry</button>
     <div id="entriesList"></div>

--- a/offline-diary/script.js
+++ b/offline-diary/script.js
@@ -7,6 +7,51 @@ const saveBtn = document.getElementById('saveEntry');
 const entriesList = document.getElementById('entriesList');
 const openBtn = document.getElementById('openFile');
 const createBtn = document.getElementById('createFile');
+const passwordInput = document.getElementById('passwordInput');
+const searchInput = document.getElementById('searchInput');
+const exportBtn = document.getElementById('exportBtn');
+const importBtn = document.getElementById('importBtn');
+const importInput = document.getElementById('importInput');
+
+document.addEventListener('DOMContentLoaded', () => {
+  const draft = localStorage.getItem('diaryDraft');
+  if (draft) entryInput.value = draft;
+  searchInput.addEventListener('input', renderEntries);
+});
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+async function getKey(password, salt, usage) {
+  const keyMaterial = await crypto.subtle.importKey('raw', enc.encode(password), {name: 'PBKDF2'}, false, ['deriveKey']);
+  return crypto.subtle.deriveKey({name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256'}, keyMaterial, {name: 'AES-GCM', length: 256}, false, usage);
+}
+
+function hex(buf) {
+  return Array.from(buf).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function hexToBuf(hexStr) {
+  const arr = hexStr.match(/.{2}/g).map(x => parseInt(x, 16));
+  return new Uint8Array(arr);
+}
+
+async function encrypt(text, password) {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await getKey(password, salt, ['encrypt']);
+  const data = await crypto.subtle.encrypt({name: 'AES-GCM', iv}, key, enc.encode(text));
+  return {salt: hex(salt), iv: hex(iv), data: btoa(String.fromCharCode(...new Uint8Array(data)))};
+}
+
+async function decrypt(obj, password) {
+  const salt = hexToBuf(obj.salt);
+  const iv = hexToBuf(obj.iv);
+  const key = await getKey(password, salt, ['decrypt']);
+  const data = Uint8Array.from(atob(obj.data), c => c.charCodeAt(0));
+  const txt = await crypto.subtle.decrypt({name: 'AES-GCM', iv}, key, data);
+  return dec.decode(txt);
+}
 
 openBtn.addEventListener('click', async () => {
   try {
@@ -34,6 +79,42 @@ createBtn.addEventListener('click', async () => {
   }
 });
 
+exportBtn.addEventListener('click', () => {
+  const csv = diary.map(e => `"${new Date(e.timestamp).toLocaleString()}","${e.text.replace(/"/g,'""')}"`).join('\n');
+  const blob = new Blob([csv], {type:'text/csv'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'diary.csv';
+  a.click();
+  URL.revokeObjectURL(url);
+});
+
+importBtn.addEventListener('click', () => importInput.click());
+
+importInput.addEventListener('change', async () => {
+  const file = importInput.files[0];
+  if (!file) return;
+  const text = await file.text();
+  try {
+    const data = JSON.parse(text);
+    if (Array.isArray(data)) {
+      diary = diary.concat(data);
+      await saveFile();
+      renderEntries();
+    } else {
+      alert('Invalid JSON file');
+    }
+  } catch {
+    alert('Could not parse file');
+  }
+  importInput.value = '';
+});
+
+entryInput.addEventListener('input', () => {
+  localStorage.setItem('diaryDraft', entryInput.value);
+});
+
 saveBtn.addEventListener('click', async () => {
   const text = entryInput.value.trim();
   if (!text) return;
@@ -54,6 +135,7 @@ saveBtn.addEventListener('click', async () => {
     diary.push(entry);
   }
   entryInput.value = '';
+  localStorage.removeItem('diaryDraft');
   await saveFile();
   renderEntries();
 });
@@ -61,13 +143,25 @@ saveBtn.addEventListener('click', async () => {
 function enableEntry() {
   entryInput.disabled = false;
   saveBtn.disabled = false;
+  searchInput.disabled = false;
+  exportBtn.disabled = false;
 }
 
 async function loadFile() {
   const file = await fileHandle.getFile();
   const text = await file.text();
   try {
-    diary = JSON.parse(text || '[]');
+    if (passwordInput.value) {
+      const obj = JSON.parse(text);
+      if (obj && obj.data && obj.iv && obj.salt) {
+        const decrypted = await decrypt(obj, passwordInput.value);
+        diary = JSON.parse(decrypted || '[]');
+      } else {
+        diary = JSON.parse(text || '[]');
+      }
+    } else {
+      diary = JSON.parse(text || '[]');
+    }
   } catch {
     diary = [];
   }
@@ -78,14 +172,20 @@ async function loadFile() {
 async function saveFile() {
   if (!fileHandle) return;
   const writable = await fileHandle.createWritable();
-  await writable.write(JSON.stringify(diary, null, 2));
+  let data = JSON.stringify(diary, null, 2);
+  if (passwordInput.value) {
+    data = JSON.stringify(await encrypt(data, passwordInput.value));
+  }
+  await writable.write(data);
   await writable.close();
 }
 
 function renderEntries() {
   entriesList.innerHTML = '';
+  const query = searchInput.value.toLowerCase();
   const sorted = diary.slice().sort((a,b) => new Date(b.timestamp) - new Date(a.timestamp));
-  for (const entry of sorted) {
+  const filtered = query ? sorted.filter(e => e.text.toLowerCase().includes(query)) : sorted;
+  for (const entry of filtered) {
     const div = document.createElement('div');
     div.className = 'entry';
     const date = document.createElement('div');

--- a/offline-diary/style.css
+++ b/offline-diary/style.css
@@ -16,6 +16,14 @@ h1 {
   margin-bottom: 10px;
   text-align: center;
 }
+#file-buttons input {
+  margin-right: 6px;
+}
+#searchInput {
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 10px;
+}
 #entryInput {
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- highlight browser support in README and document new features
- add password, search, export and import controls to the UI
- support draft auto-save, search filtering, encryption and CSV export
- tweak styles for new inputs

## Testing
- `node --check offline-diary/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68401493b4188327b8653b71437a4152