### PR TITLE
Remove agent code from offline diary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore node_modules and archives
+node_modules/
+*.zip
+lune-interface/server/node_modules/
+lune-interface/client/node_modules/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Offline Diary App
 
-This repository includes a minimal diary application located in `offline-diary/`.
+This repository focuses on a minimal diary located in `offline-diary/`.
 The app works entirely in the browser using the File System Access API so it can
-function offline without a backend server or agent.
+function offline with no backend server or agent logic required. The previous
+server-side agent routes remain in the repository but are commented out so the
+diary can run fully offline.
 
 ## Browser Support
 
@@ -19,3 +21,9 @@ This app requires a browser with File System Access API support, such as Chrome 
 8. Use **Export** to download a CSV copy and **Import** to merge entries from another JSON file.
 
 Entries are stored as an array of objects with `id`, `text` and `timestamp`.
+
+### Repository cleanup
+
+Large dependencies such as `node_modules` and the archived `lune-interface.zip`
+have been removed and are ignored via `.gitignore` to keep the project small and
+focused on the offline diary.

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const diaryStore = require('../diaryStore');
-const resistor = require('../controllers/resistor');
-const interpreter = require('../controllers/interpreter');
-const forge = require('../controllers/forge');
-const lune = require('../controllers/lune');
+// Agent controllers are not used in offline mode
+// const resistor = require('../controllers/resistor');
+// const interpreter = require('../controllers/interpreter');
+// const forge = require('../controllers/forge');
+// const lune = require('../controllers/lune');
 
 // Create a diary entry (accepts 'text' or legacy 'content')
 router.post('/', async (req, res) => {
@@ -15,15 +16,7 @@ router.post('/', async (req, res) => {
     }
     const entry = await diaryStore.add(text);
 
-    // Trigger simple agent processing sequentially
-    try {
-      await resistor.processEntry(entry);
-      await interpreter.processEntry(entry);
-      await forge.processEntry(entry);
-      await lune.processEntry(entry);
-    } catch (err) {
-      console.error('Agent processing failed:', err);
-    }
+    // Agent processing disabled for offline diary
 
     res.status(201).json(entry);
   } catch (err) {
@@ -50,14 +43,7 @@ router.put('/:id', async (req, res) => {
     }
     const entry = await diaryStore.updateText(req.params.id, text);
     if (!entry) return res.status(404).json({ error: 'Entry not found.' });
-    try {
-      await resistor.processEntry(entry);
-      await interpreter.processEntry(entry);
-      await forge.processEntry(entry);
-      await lune.processEntry(entry);
-    } catch (err) {
-      console.error('Agent processing failed:', err);
-    }
+    // Agent processing disabled for offline diary
     res.json(entry);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/lune-interface/server/server.js
+++ b/lune-interface/server/server.js
@@ -1,15 +1,16 @@
 // server.js (FINAL, most reliable dotenv loading for Windows + Node)
 const express = require('express');
 const cors = require('cors');
-const luneRoutes = require('./routes/lune');
-const processingRoutes = require('./routes/processing');
+// Agent routes are disabled for offline diary usage
+// const luneRoutes = require('./routes/lune');
+// const processingRoutes = require('./routes/processing');
 
 const dotenv = require('dotenv');
 // Only ONE dotenv.config() call needed!
 dotenv.config(); // Looks for .env in same folder as server.js
 
 // --- Debug: print your key to verify env loads ---
-console.log('OpenAI key loaded:', process.env.OPENAI_API_KEY);
+// console.log('OpenAI key loaded:', process.env.OPENAI_API_KEY);
 
 const app = express();
 const port = process.env.PORT || 5001;
@@ -21,8 +22,8 @@ app.use(express.json());
 // --- Routes ---
 const diaryRoutes = require('./routes/diary');
 app.use('/diary', diaryRoutes);
-app.use('/api/lune', luneRoutes); // <-- Lune chat API: /api/lune/send
-app.use('/api/processing', processingRoutes);
+// app.use('/api/lune', luneRoutes); // <-- Lune chat API: /api/lune/send
+// app.use('/api/processing', processingRoutes);
 
 // No database connection needed; diary entries are stored in diary.json
 


### PR DESCRIPTION
## Summary
- disable agent routes and controllers in the Node server
- update README for offline-first diary setup and cleanup info
- add repo `.gitignore` to avoid tracking `node_modules` and archives

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68401ebb6a6083279dc131005ee5fa1f