### PR TITLE
Fix: Update diary save path to offline-diary/diary.json

### DIFF
--- a/lune-interface/server/diaryStore.js
+++ b/lune-interface/server/diaryStore.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
-const DATA_FILE = path.join(__dirname, 'diary.json');
+const DATA_FILE = path.join(__dirname, '..', '..', 'offline-diary', 'diary.json');
 
 let diary = [];
 


### PR DESCRIPTION
The diary entries were previously being saved in `lune-interface/server/diary.json`. This change updates the path in `lune-interface/server/diaryStore.js` to correctly save entries in the `offline-diary/diary.json` file as intended.