### PR TITLE
Make entries clickable for editing

### DIFF
--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -15,7 +15,11 @@ export default function EntriesPage({ entries, refreshEntries, startEdit }) {
       <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center">Entries</h1>
       <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto">
         {entries.map(entry => (
-          <div key={entry.id} className="bg-white p-3 rounded shadow">
+          <div
+            key={entry.id}
+            className="bg-white p-3 rounded shadow cursor-pointer"
+            onClick={() => { startEdit(entry.id); navigate('/chat'); }}
+          >
             <div className="text-xs text-luneDarkGray">{new Date(entry.timestamp).toLocaleString()}</div>
             <div className="whitespace-pre-wrap mb-2">{entry.text}</div>
             {entry.agent_logs?.Lune && (
@@ -23,8 +27,12 @@ export default function EntriesPage({ entries, refreshEntries, startEdit }) {
                 <span className="font-semibold">Lune:</span> {entry.agent_logs.Lune.reflection}
               </div>
             )}
-            <button onClick={() => { startEdit(entry.id); navigate('/chat'); }} className="text-sm text-lunePurple mr-2">Edit</button>
-            <button onClick={() => handleDelete(entry.id)} className="text-sm text-red-600">Delete</button>
+            <button
+              onClick={(e) => { e.stopPropagation(); handleDelete(entry.id); }}
+              className="text-sm text-red-600"
+            >
+              Delete
+            </button>
           </div>
         ))}
         {entries.length === 0 && <div className="text-center text-luneDarkGray">No entries.</div>}


### PR DESCRIPTION
## Summary
- wrap each entry in `EntriesPage` with a clickable container
- remove dedicated Edit button
- prevent delete button from triggering edit

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68417cb9395483279eaec4577f938a2d