### PR TITLE
Update DockChat with chat modal and upload

### DIFF
--- a/lune-interface/client/src/App.test.js
+++ b/lune-interface/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders dock chat heading', () => {
+test('renders lune diary heading', () => {
   render(<App />);
-  const headingElement = screen.getByText(/dock chat/i);
+  const headingElement = screen.getByText(/lune diary./i);
   expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update DockChat heading and add chat modal
- support diary JSON upload
- adjust test for new heading

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68417cbd933483278f3abb5d5c4527d4