### PR TITLE
Refactor: Adjust chat logging to save one file per session

### DIFF
--- a/lune-interface/server/controllers/lune.js
+++ b/lune-interface/server/controllers/lune.js
@@ -14,11 +14,13 @@ const openai = new OpenAI({
 exports.handleUserMessage = async (req, res) => {
   const { entries, conversation } = req.body;
   // Persist the conversation so far
+  /*
   try {
     await chatLogStore.add(conversation || []);
   } catch (err) {
     console.error('Failed to save chat log:', err);
   }
+  */
   const systemMessage = {
     role: "system",
     content: "You are Lune, a helpful, reflective journaling companion. You receive the user's diary entries as context and should use them to provide thoughtful, supportive responses."


### PR DESCRIPTION
Previously, chat logs were saved incrementally after each of your messages and then again when the chat modal was closed. This resulted in multiple, partial log files for a single conversation.

This commit modifies the chat logging mechanism:
- Removed the incremental log saving from the `handleUserMessage` controller function.
- Chat logs are now saved only once when the Lune chat modal is closed, ensuring that a single JSON file containing the complete conversation is stored in `offline-diary/chatlogs/`.

This change makes the chat logs cleaner and easier for me to parse for context, as per your requirements. Diary entry functionality and storage remain unchanged and were verified to align with the specified behavior.