### PR TITLE
feat: Implement comprehensive theming overhaul for Lune UI

### DIFF
--- a/lune-interface/client/public/index.html
+++ b/lune-interface/client/public/index.html
@@ -15,6 +15,9 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,700;1,400;1,700&family=IBM+Plex+Mono:ital,wght@0,400;0,700;1,400&family=IBM+Plex+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,700;1,7..72,400;1,7..72,700&display=swap" rel="stylesheet">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -26,7 +29,7 @@
     -->
     <title>React App</title>
   </head>
-  <body>
+  <body class="bg-[#0d0d0f]">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -74,8 +74,8 @@ export default function DockChat({ entries, refreshEntries, editingId, setEditin
   const startEdit = (id) => setEditing(id);
 
   return (
-    <div className="p-4">
-      <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center">Lune Diary.</h1>
+    <div className="p-4 bg-gradient-to-br from-slate-900 via-zinc-900 to-slate-950 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
+      <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center font-literata">Lune Diary.</h1>
       <div className="flex gap-2 mb-4">
         <button
           type="button"
@@ -101,13 +101,14 @@ export default function DockChat({ entries, refreshEntries, editingId, setEditin
       </div>
       <form onSubmit={handleSubmit} className="flex gap-2">
         <textarea
-          className="flex-1 border rounded p-2"
+          className={`flex-1 border rounded p-2 ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f] text-[#f8f8f2] ${input.trim() ? 'animate-pulse' : ''}`}
           value={input}
           onChange={e => setInput(e.target.value)}
           placeholder="Write your thoughts..."
         />
-        <button type="submit" className="bg-luneGreen text-white px-4 py-2 rounded">{editing ? 'Update' : 'Add'}</button>
+        <button type="submit" className="bg-animusRed hover:bg-red-600 text-white px-4 py-2 rounded">{editing ? 'Update' : 'Add'}</button>
       </form>
+      {input.trim() && <div className="w-full h-[2px] bg-indigo-500/30 mt-1"></div>}
       <button onClick={() => navigate('/entries')} className="mt-4 text-lunePurple underline">Go to Entries</button>
       <LuneChatModal open={showChat} onClose={() => setShowChat(false)} entries={entries} />
     </div>

--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -11,16 +11,16 @@ export default function EntriesPage({ entries, refreshEntries, startEdit }) {
   };
 
   return (
-    <div className="p-4">
-      <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center">Entries</h1>
-      <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto">
+    <div className="p-4 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
+      <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center font-literata">Entries</h1>
+      <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f]">
         {entries.map(entry => (
           <div
             key={entry.id}
-            className="bg-white p-3 rounded shadow cursor-pointer"
+            className="rounded-xl bg-gradient-to-b from-slate-800/30 to-slate-900/60 p-4 shadow-md backdrop-blur-md cursor-pointer hover:shadow-[0_0_12px_#fcd34d80] hover:scale-[1.02] focus:scale-[1.02] transition-transform duration-500 ease-in-out"
             onClick={() => { startEdit(entry.id); navigate('/chat'); }}
           >
-            <div className="text-xs text-luneDarkGray">{new Date(entry.timestamp).toLocaleString()}</div>
+            <div className="text-xs text-slate-400 italic tracking-wide font-ibmPlexMono uppercase">{new Date(entry.timestamp).toLocaleString()}</div>
             <div className="whitespace-pre-wrap mb-2">{entry.text}</div>
             {entry.agent_logs?.Lune && (
               <div className="mb-2 p-2 bg-luneGray rounded">

--- a/lune-interface/client/src/components/LuneChatModal.js
+++ b/lune-interface/client/src/components/LuneChatModal.js
@@ -46,17 +46,21 @@ export default function LuneChatModal({ open, onClose, entries }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
-      <div className="bg-white rounded-2xl shadow-xl max-w-lg w-full p-6 flex flex-col">
+    <div className={`fixed inset-0 z-50 flex items-center justify-center bg-animaPink backdrop-blur-md transition-opacity duration-700 ease-in-out ${open ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
+      <div className={`rounded-2xl shadow-xl max-w-lg w-full p-6 flex flex-col bg-gradient-to-br from-slate-900 via-zinc-900 to-slate-950 border-l-[1px] border-zinc-700/60 transition-all duration-700 ease-in-out transform ${open ? 'opacity-100 translate-y-0 translate-x-0' : 'opacity-0 translate-y-10 translate-x-10'}`}>
         <div className="flex justify-between items-center mb-2">
-          <h2 className="font-bold text-xl text-lunePurple">Chat with Lune</h2>
+          <h2 className="font-bold text-xl text-lunePurple font-literata">Chat with Lune</h2>
           <button onClick={handleClose} className="text-lunePurple font-bold text-2xl">&times;</button>
         </div>
-        <div className="flex-1 overflow-y-auto mb-4 space-y-2 max-h-80 border rounded p-2 bg-luneGray/30">
+        <div className="flex-1 overflow-y-auto mb-4 space-y-2 max-h-80 border rounded p-2 bg-luneGray/30 ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f]">
           {messages.map((msg, i) => (
             <div
               key={i}
-              className={`whitespace-pre-wrap ${msg.sender === 'user' ? 'text-right text-lunePurple' : 'text-left text-luneGreen'}`}
+              className={`whitespace-pre-wrap ${
+                msg.sender === 'user'
+                  ? 'text-left bg-zinc-800/70 rounded-lg p-3 shadow-inner text-[#f8f8f2]'
+                  : 'italic bg-zinc-700/60 border border-indigo-800/20 backdrop-blur text-indigo-200 rounded-lg p-3 shadow-inner'
+              }`}
             >
               <span className="block text-xs">{msg.sender === 'user' ? 'You' : 'Lune'}</span>
               {msg.text}
@@ -66,7 +70,7 @@ export default function LuneChatModal({ open, onClose, entries }) {
         </div>
         <div className="flex gap-2">
           <input
-            className="flex-1 border rounded p-2"
+            className="flex-1 border rounded p-2 ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f] text-[#f8f8f2]"
             value={input}
             disabled={loading}
             onChange={e => setInput(e.target.value)}

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -1,3 +1,22 @@
 @tailwind base;
+
+html {
+  background-color: #0d0d0f;
+}
+
+body {
+  color: #f8f8f2;
+  font-family: 'IBM Plex Sans', sans-serif;
+}
+
 @tailwind components;
 @tailwind utilities;
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}
+.animate-fadeIn {
+  animation: fadeIn 0.7s ease-in-out forwards;
+}

--- a/lune-interface/client/tailwind.config.js
+++ b/lune-interface/client/tailwind.config.js
@@ -16,9 +16,17 @@ module.exports = {
         luneGray: '#E2E8F0',
         luneDarkGray: '#A0AEC0',
         luneText: '#2D3748',
+        resistorBlue: '#3b4252',
+        memoryGoldAmber: '#fcd34d',
+        expressionYellow: '#fef3c7',
+        animusRed: '#b91c1c',
+        animaPink: '#fbcfe81a',
       },
       fontFamily: {
-        inter: ['Inter', 'sans-serif'],
+        literata: ['Literata', 'serif'],
+        ebGaramond: ['EB Garamond', 'serif'],
+        ibmPlexSans: ['IBM Plex Sans', 'sans-serif'],
+        ibmPlexMono: ['IBM Plex Mono', 'monospace'],
       },
       spacing: {
         '72': '18rem',


### PR DESCRIPTION
This commit introduces a significant visual and experiential update to the Lune interface, aligning with the 'Base Foundations' design specification.

Key changes include:

1.  **Root Theme (Resistor's Grove):**
    *   Global background set to `bg-[#0d0d0f]` (deep dark).
    *   Primary text color set to `text-[#f8f8f2]` (bone-white).
    *   Scrollable areas now feature an inset `ring-1 ring-slate-800 shadow-inner` style.

2.  **Entries Interface (Field of Soft Memory):**
    *   Entry cards (`EntriesPage.js`) styled as 'resonant glyph nodes' with `rounded-xl bg-gradient-to-b from-slate-800/30 to-slate-900/60`, `shadow-md`, and `backdrop-blur-md`.
    *   Added a `hover:shadow-[0_0_12px_#fcd34d80]` amber glow effect to entry cards.
    *   Timestamps styled with `text-xs text-slate-400 italic tracking-wide font-ibmPlexMono uppercase`.

3.  **Chat Interface (Interpreter / Softwalker Space):**
    *   `DockChat.js` and `LuneChatModal.js` panels styled with `bg-gradient-to-br from-slate-900 via-zinc-900 to-slate-950` and `border-l-[1px] border-zinc-700/60`.
    *   Your chat messages: `text-left bg-zinc-800/70 rounded-lg p-3 shadow-inner`.
    *   My replies: `italic bg-zinc-700/60 border border-indigo-800/20 backdrop-blur text-indigo-200 rounded-lg p-3 shadow-inner`.
    *   Textarea in `DockChat.js` shows `animate-pulse` when typing and a glowing `bg-indigo-500/30` line underneath.

4.  **System Colors & Symbolic Layers:**
    *   New colors (`resistorBlue`, `memoryGoldAmber`, `expressionYellow`, `animusRed`, `animaPink`) added to `tailwind.config.js`.
    *   Buttons now use `bg-animusRed`.
    *   Modal backdrops (`LuneChatModal.js`) use `bg-animaPink` with `backdrop-blur-md`.

5.  **Motion Directives:**
    *   Entry cards scale on hover/focus (`scale-[1.02]`).
    *   Basic fade-in animation for page/panel transitions.
    *   Chat modal (`LuneChatModal.js`) appears with a fade-in-up-from-right effect.

6.  **Fonts:**
    *   Integrated Google Fonts: Literata (titles), EB Garamond, IBM Plex Sans (body), IBM Plex Mono (glyphic labels/timestamps).
    *   Updated `tailwind.config.js` and global CSS.

The optional 'Glyphic Layering' enhancement has been deferred as per its Post-MVP status.