### PR TITLE
Fix: Improve npm install robustness in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,10 +8,12 @@ ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 cd "$ROOT_DIR/lune-interface/server"
 echo "Installing server dependencies..."
+npm cache clean --force
 npm install
 
 cd "$ROOT_DIR/lune-interface/client"
 echo "Installing client dependencies..."
+npm cache clean --force
 npm install
 
 cat <<'EOM'
@@ -21,5 +23,11 @@ Setup complete. Before starting the application, ensure you edit 'lune-interface
 To launch the development servers, run:
   (1) cd lune-interface/server && npm start
   (2) cd lune-interface/client && npm start
+
+If you encounter any issues during or after setup, please also:
+  - Ensure you have a stable internet connection.
+  - Check for sufficient disk space.
+  - Verify write permissions for project directories and npm's global cache directory.
+  - Consider updating Node.js and npm to their latest stable versions if problems persist.
 EOM
 


### PR DESCRIPTION
Adds 'npm cache clean --force' before client and server dependency installations in the setup.sh script. This helps prevent 'tar ENTRY ERROR' and similar issues caused by a corrupted npm cache.

Also appends further troubleshooting advice to the setup script, guiding you to check network stability, disk space, permissions, and Node/npm versions if installation problems persist.