### PR TITLE
Fix: Resolve client-side react-scripts error and ESLint warning

### DIFF
--- a/lune-interface/.gitignore
+++ b/lune-interface/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+server/node_modules

--- a/lune-interface/client/package-lock.json
+++ b/lune-interface/client/package-lock.json
@@ -15160,16 +15160,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -71,7 +71,7 @@ export default function DockChat({ entries, refreshEntries, editingId, setEditin
     e.target.value = '';
   };
 
-  const startEdit = (id) => setEditing(id);
+  // const startEdit = (id) => setEditing(id);
 
   return (
     <div className="p-4 bg-gradient-to-br from-slate-900 via-zinc-900 to-slate-950 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">

--- a/lune-interface/server/.gitignore
+++ b/lune-interface/server/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
- I reinstalled client dependencies to ensure `react-scripts` is available, addressing the 'command not found' error. `npm run build` is now successful.
- I fixed an ESLint warning in `DockChat.js` by commenting out an unused variable.

Note: The server-side `axios` 'Invalid package config' error could not be resolved due to limitations with the tracked `node_modules` directory and an inconsistent `package-lock.json`. Manual intervention in your local environment is required for the server.