### PR TITLE
Add prop type checks

### DIFF
--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import LuneChatModal from './LuneChatModal';
 
@@ -114,3 +115,10 @@ export default function DockChat({ entries, refreshEntries, editingId, setEditin
     </div>
   );
 }
+
+DockChat.propTypes = {
+  entries: PropTypes.array.isRequired,
+  refreshEntries: PropTypes.func.isRequired,
+  editingId: PropTypes.any,
+  setEditingId: PropTypes.func,
+};

--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 
 export default function EntriesPage({ entries, refreshEntries, startEdit }) {
@@ -41,3 +42,9 @@ export default function EntriesPage({ entries, refreshEntries, startEdit }) {
     </div>
   );
 }
+
+EntriesPage.propTypes = {
+  entries: PropTypes.array.isRequired,
+  refreshEntries: PropTypes.func.isRequired,
+  startEdit: PropTypes.func.isRequired,
+};

--- a/lune-interface/client/src/components/LuneChatModal.js
+++ b/lune-interface/client/src/components/LuneChatModal.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 
 export default function LuneChatModal({ open, onClose, entries }) {
   const [messages, setMessages] = useState([]);
@@ -150,3 +151,9 @@ export default function LuneChatModal({ open, onClose, entries }) {
     </div>
   );
 }
+
+LuneChatModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  entries: PropTypes.array.isRequired,
+};


### PR DESCRIPTION
## Summary
- add PropTypes validation for DockChat, EntriesPage and LuneChatModal components

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684a8948fdcc8327809d123ebc4328f8