### PR TITLE
Fix sessionId for n8n Simple Memory

### DIFF
--- a/lune-interface/server/controllers/lune.js
+++ b/lune-interface/server/controllers/lune.js
@@ -25,6 +25,7 @@ exports.handleUserMessage = async (req, res) => {
     const webhookUrl = 'https://mystc-myst.app.n8n.cloud/webhook/9f5ad6f1-d4a7-43a6-8c13-4b1c0e76bb4e/chat';
     const userMessage = conversation && conversation.length > 0 ? conversation[conversation.length - 1].text : null;
     const data = {
+      sessionId: 'test-session-1', // required for n8n Simple Memory node
       diaryEntries: entries,
       userMessage: userMessage
       // luneResponse is removed as n8n will provide it


### PR DESCRIPTION
## Summary
- include a static `sessionId` when forwarding chat requests to n8n

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684a946692748327a30064061b9d1cab