### PR TITLE
Refactor chat webhook payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To enable conversations with Lune uncomment the line enabling the route in
 Once enabled the React app shows a **Chat with Lune** button. Messages are
 sent to `/api/lune/send` and the conversation history is written under
 `offline-diary/chatlogs/`.
+The webhook payload now only includes `{ sessionId, userMessage }` for clarity and security.
 
 The chat modal now shows a spinner while waiting for Lune's reply. After
 around 8&nbsp;seconds a friendly notice appears informing the user that the

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -111,7 +111,7 @@ export default function DockChat({ entries, refreshEntries, editingId, setEditin
       </form>
       {input.trim() && <div className="w-full h-[2px] bg-indigo-500/30 mt-1"></div>}
       <button onClick={() => navigate('/entries')} className="mt-4 text-lunePurple underline">Go to Entries</button>
-      <LuneChatModal open={showChat} onClose={() => setShowChat(false)} entries={entries} />
+      <LuneChatModal open={showChat} onClose={() => setShowChat(false)} />
     </div>
   );
 }

--- a/lune-interface/client/src/components/LuneChatModal.js
+++ b/lune-interface/client/src/components/LuneChatModal.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-export default function LuneChatModal({ open, onClose, entries }) {
+export default function LuneChatModal({ open, onClose }) {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
@@ -97,9 +97,8 @@ export default function LuneChatModal({ open, onClose, entries }) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          entries, // assuming 'entries' is available in this scope
-          conversation: [userMessage] // Send only the latest user message for context to n8n if that's the design
-                                    // Or pass 'newMessages' if n8n expects the whole conversation history up to this point
+          sessionId: 'test-session-1',
+          userMessage: userMessage.text
         }),
       });
 
@@ -176,5 +175,4 @@ export default function LuneChatModal({ open, onClose, entries }) {
 LuneChatModal.propTypes = {
   open: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
-  entries: PropTypes.array.isRequired,
 };

--- a/lune-interface/server/controllers/lune.js
+++ b/lune-interface/server/controllers/lune.js
@@ -10,24 +10,15 @@ if (!process.env.OPENAI_API_KEY) {
 
 
 exports.handleUserMessage = async (req, res) => {
-  const { entries, conversation } = req.body;
-  // Persist the conversation so far
-  /*
-  try {
-    await chatLogStore.add(conversation || []);
-  } catch (err) {
-    console.error('Failed to save chat log:', err);
-  }
-  */
+  const { sessionId, userMessage } = req.body;
+  // Conversation logging omitted since only userMessage is sent
 
   // Send data to n8n webhook
   try {
     const webhookUrl = 'https://mystc-myst.app.n8n.cloud/webhook/9f5ad6f1-d4a7-43a6-8c13-4b1c0e76bb4e/chat';
-    const userMessage = conversation && conversation.length > 0 ? conversation[conversation.length - 1].text : null;
     const data = {
-      sessionId: 'test-session-1', // required for n8n Simple Memory node
-      diaryEntries: entries,
-      userMessage: userMessage
+      sessionId: sessionId || 'test-session-1',
+      userMessage
       // luneResponse is removed as n8n will provide it
     };
     await axios.post(webhookUrl, data, {


### PR DESCRIPTION
## Summary
- send minimal payload from the chat modal
- update the server controller to expect `sessionId` and `userMessage`
- drop unused `entries` prop in `LuneChatModal`
- document the new payload in the README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae3b539f4832789a951995fe9e71c