### PR TITLE
Refactor n8n response flow

### DIFF
--- a/lune-interface/server/controllers/lune.js
+++ b/lune-interface/server/controllers/lune.js
@@ -2,8 +2,6 @@
 const axios = require('axios'); // Added axios import
 const chatLogStore = require('../chatLogStore');
 
-let lastN8nResponse = null; // Variable to store n8n response
-
 if (!process.env.OPENAI_API_KEY) {
   console.warn('Warning: OPENAI_API_KEY is not set. Lune replies will fail.');
 }
@@ -13,25 +11,29 @@ exports.handleUserMessage = async (req, res) => {
   const { sessionId, userMessage } = req.body;
   // Conversation logging omitted since only userMessage is sent
 
-  // Send data to n8n webhook
   try {
-    const webhookUrl = 'https://mystc-myst.app.n8n.cloud/webhook/9f5ad6f1-d4a7-43a6-8c13-4b1c0e76bb4e/chat';
+    const webhookUrl =
+      'https://mystc-myst.app.n8n.cloud/webhook/9f5ad6f1-d4a7-43a6-8c13-4b1c0e76bb4e/chat';
     const data = {
       sessionId: sessionId || 'test-session-1',
-      userMessage
-      // luneResponse is removed as n8n will provide it
+      userMessage,
     };
-    await axios.post(webhookUrl, data, {
+
+    const webhookRes = await axios.post(webhookUrl, data, {
       headers: {
-        'Content-Type': 'application/json'
-      }
+        'Content-Type': 'application/json',
+      },
     });
-    // If the webhook call is successful, send an acknowledgment to the client
-    res.status(202).json({ message: "Request received, processing via n8n." });
+
+    const reply =
+      webhookRes.data && typeof webhookRes.data === 'object'
+        ? webhookRes.data.message ?? webhookRes.data
+        : webhookRes.data;
+
+    res.status(200).json({ aiReply: reply });
   } catch (webhookError) {
-    console.error('Error sending data to n8n webhook:', webhookError);
-    // If the webhook call fails, inform the client
-    res.status(500).json({ error: "Failed to forward message to n8n." });
+    console.error('Error communicating with n8n webhook:', webhookError);
+    res.status(500).json({ error: 'Failed to communicate with n8n.' });
   }
 };
 
@@ -65,24 +67,3 @@ exports.processEntry = async function(entry) {
   await diaryStore.saveEntry(entry);
 };
 
-exports.receiveN8nResponse = (req, res) => {
-  const { message } = req.body;
-
-  if (!message) {
-    return res.status(400).json({ error: "Missing 'message' in request body." });
-  }
-
-  lastN8nResponse = message;
-  console.log('Received message from n8n:', lastN8nResponse); // Optional: log received message
-  res.status(200).json({ message: "Response received and stored." });
-};
-
-exports.getN8nResponse = (req, res) => {
-  if (lastN8nResponse !== null) {
-    const messageToReturn = lastN8nResponse;
-    lastN8nResponse = null; // Clear the message after retrieving it
-    res.status(200).json({ message: messageToReturn });
-  } else {
-    res.status(200).json({ message: null }); // No new message
-  }
-};

--- a/lune-interface/server/routes/lune.js
+++ b/lune-interface/server/routes/lune.js
@@ -5,11 +5,4 @@ const luneController = require('../controllers/lune');
 // POST /lune/send
 router.post('/send', luneController.handleUserMessage);
 router.post('/log', luneController.saveConversationLog);
-
-// POST /lune/n8n_response - New route for receiving messages from n8n
-router.post('/n8n_response', luneController.receiveN8nResponse);
-
-// GET /lune/get_n8n_response - New route for client to poll for n8n messages
-router.get('/get_n8n_response', luneController.getN8nResponse);
-
 module.exports = router;


### PR DESCRIPTION
## Summary
- await the n8n webhook directly and reply with `aiReply`
- drop temporary webhook polling endpoints

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684aedac8c64832790a210b41db1b0df