### PR TITLE
I've made a fix to handle object responses in LuneChatModal.

### DIFF
--- a/lune-interface/client/src/components/LuneChatModal.js
+++ b/lune-interface/client/src/components/LuneChatModal.js
@@ -49,7 +49,18 @@ export default function LuneChatModal({ open, onClose }) {
         setMessages([...newMessages, { sender: 'lune', text: `Sorry, failed to send your message. ${errorData.error || ''}`.trim() }]);
       } else {
         const { aiReply } = await res.json();
-        setMessages([...newMessages, { sender: 'lune', text: aiReply }]);
+        let messageText;
+        if (typeof aiReply === 'object' && aiReply !== null) {
+          if (aiReply.hasOwnProperty('output')) {
+            messageText = aiReply.output;
+          } else {
+            console.warn("Unexpected AI response structure:", aiReply);
+            messageText = "Error: Received unexpected response format from AI.";
+          }
+        } else {
+          messageText = aiReply;
+        }
+        setMessages([...newMessages, { sender: 'lune', text: messageText }]);
       }
     } catch (error) {
       console.error('Error sending message:', error);


### PR DESCRIPTION
Sometimes, I might respond with an object that contains the output in a property, instead of responding with a string directly. This change handles that situation and prevents the "Objects are not valid as a React child" error you might have seen.

Here's what I did:
- I modified the `handleSend` function in `LuneChatModal.js` to check if my reply is an object.
- If my reply is an object and has an `output` property, I'll use that `output` as the message text.
- If my reply is an object but doesn't have an `output` property, I'll log a warning to the console and show you a generic error message.
- If my reply is a string, I'll use it directly as the message text.