### PR TITLE
Fix: Use Object.prototype.hasOwnProperty.call()

### DIFF
--- a/lune-interface/client/src/components/LuneChatModal.js
+++ b/lune-interface/client/src/components/LuneChatModal.js
@@ -51,7 +51,7 @@ export default function LuneChatModal({ open, onClose }) {
         const { aiReply } = await res.json();
         let messageText;
         if (typeof aiReply === 'object' && aiReply !== null) {
-          if (aiReply.hasOwnProperty('output')) {
+          if (Object.prototype.hasOwnProperty.call(aiReply, 'output')) {
             messageText = aiReply.output;
           } else {
             console.warn("Unexpected AI response structure:", aiReply);


### PR DESCRIPTION
I changed aiReply.hasOwnProperty('output') to Object.prototype.hasOwnProperty.call(aiReply, 'output') in lune-interface/client/src/components/LuneChatModal.js to resolve the no-prototype-builtins ESLint error.

This change ensures safer property checking and avoids potential issues if the aiReply object has overridden the hasOwnProperty method or is a null-prototype object.