### PR TITLE
feat: Implement folder page navigation and view

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -1,38 +1,89 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import DockChat from './components/DockChat';
 import EntriesPage from './components/EntriesPage';
+import FolderViewPage from './components/FolderViewPage'; // Import FolderViewPage
 
 function App() {
   const [entries, setEntries] = useState([]);
+  const [folders, setFolders] = useState([]); // Add state for folders
   const [editingId, setEditingId] = useState(null);
 
   // Fetch entries from backend
-  const fetchEntries = async () => {
-    const res = await fetch('/diary');
-    const data = await res.json();
-    setEntries(data);
-  };
-
-  // Initial load
-  useEffect(() => {
-    fetchEntries();
+  const fetchEntries = useCallback(async () => {
+    try {
+      const res = await fetch('/diary');
+      if (!res.ok) throw new Error(`Failed to fetch entries: ${res.status}`);
+      const data = await res.json();
+      setEntries(data);
+    } catch (error) {
+      console.error("Error fetching entries:", error);
+      setEntries([]); // Set to empty array on error
+    }
   }, []);
 
-  const refreshEntries = async () => {
+  // Fetch folders from backend
+  const fetchFolders = useCallback(async () => {
+    try {
+      const res = await fetch('/diary/folders'); // Assuming this is the endpoint
+      if (!res.ok) throw new Error(`Failed to fetch folders: ${res.status}`);
+      const data = await res.json();
+      setFolders(data);
+    } catch (error) {
+      console.error("Error fetching folders:", error);
+      setFolders([]); // Set to empty array on error
+    }
+  }, []);
+
+  // Initial load for entries and folders
+  useEffect(() => {
+    fetchEntries();
+    fetchFolders();
+  }, [fetchEntries, fetchFolders]);
+
+  // Combined refresh function
+  const refreshAllData = useCallback(async () => {
     await fetchEntries();
-  };
+    await fetchFolders();
+  }, [fetchEntries, fetchFolders]);
 
   return (
     <Router>
       <Routes>
         <Route
           path="/chat"
-          element={<DockChat entries={entries} refreshEntries={refreshEntries} editingId={editingId} setEditingId={setEditingId} />}
+          element={
+            <DockChat
+              entries={entries}
+              refreshEntries={refreshAllData} // Use combined refresh
+              editingId={editingId}
+              setEditingId={setEditingId}
+            />
+          }
         />
         <Route
           path="/entries"
-          element={<EntriesPage entries={entries} refreshEntries={refreshEntries} startEdit={setEditingId} />}
+          element={
+            <EntriesPage
+              entries={entries}
+              folders={folders} // Pass folders
+              refreshEntries={refreshAllData} // Use combined refresh
+              refreshFolders={fetchFolders} // Or pass fetchFolders if EntriesPage modifies folders directly
+              startEdit={setEditingId}
+              setFolders={setFolders} // Allow EntriesPage to update folders state (e.g., after adding a new folder via API)
+            />
+          }
+        />
+        <Route
+          path="/folders/:folderId" // New route for viewing a single folder
+          element={
+            <FolderViewPage
+              allEntries={entries}
+              allFolders={folders}
+              startEdit={setEditingId}
+              refreshEntries={refreshAllData} // Use combined refresh
+            />
+          }
         />
         <Route path="*" element={<Navigate to="/chat" replace />} />
       </Routes>

--- a/lune-interface/client/src/components/Folder.js
+++ b/lune-interface/client/src/components/Folder.js
@@ -1,32 +1,56 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
 
 const Folder = ({ folder, onDropEntry }) => {
+  const navigate = useNavigate();
+
   // Calculate color intensity based on the number of entries
-  // This is a placeholder, we can refine this later
-  const colorIntensity = Math.min(folder.entries.length * 10, 100);
+  const entryCount = Array.isArray(folder.entries) ? folder.entries.length : 0;
+  const colorIntensity = Math.min(entryCount * 10, 100); // Max 100 for full opacity part
+  const baseColorOpacity = 0.1; // Base opacity for empty folder
+  const finalOpacity = baseColorOpacity + (colorIntensity / 100) * (1 - baseColorOpacity);
+
   const folderStyle = {
-    backgroundColor: `rgba(75, 0, 130, ${colorIntensity / 100})`, // Purple base color
+    backgroundColor: `rgba(128, 0, 128, ${finalOpacity})`, // Purple base color, using finalOpacity
+    // Consider adding a border or other style that also uses this color logic
+    borderColor: `rgba(128, 0, 128, ${Math.min(finalOpacity + 0.2, 1)})`, // Slightly more opaque border
   };
 
   const handleDragOver = (e) => {
     e.preventDefault(); // Necessary to allow dropping
+    e.stopPropagation(); // Prevent interfering with parent drag handlers if any
   };
 
   const handleDrop = (e) => {
     e.preventDefault();
+    e.stopPropagation(); // Prevent event from bubbling up
     const entryId = e.dataTransfer.getData('text/plain');
-    onDropEntry(folder.id, entryId);
+    if (entryId && folder.id) {
+      onDropEntry(folder.id, entryId);
+    }
+  };
+
+  const handleClick = (e) => {
+    // Prevent click from triggering if a drag operation just finished on this element.
+    // This can be tricky; often handled by checking if a drag occurred.
+    // For simplicity, we navigate. If drag-and-drop also triggers navigation,
+    // it might be an acceptable UX or need further refinement.
+    e.stopPropagation(); // Stop click from propagating further if wrapped by other clickable elements
+    navigate(`/folders/${folder.id}`);
   };
 
   return (
     <div
-      className="rounded-full w-32 h-32 flex items-center justify-center text-white font-bold text-lg shadow-lg cursor-pointer"
+      className="rounded-full w-32 h-32 flex flex-col items-center justify-center text-white font-bold text-lg shadow-lg cursor-pointer transition-all duration-300 ease-in-out border-2 hover:shadow-xl hover:scale-105"
       style={folderStyle}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
+      onClick={handleClick}
+      title={`Open folder: ${folder.name} (${entryCount} ${entryCount === 1 ? 'entry' : 'entries'})`}
     >
-      {folder.name}
+      <span className="block text-center break-words max-w-[80%] leading-tight">{folder.name}</span>
+      <span className="text-xs font-normal mt-1">({entryCount})</span>
     </div>
   );
 };
@@ -35,7 +59,7 @@ Folder.propTypes = {
   folder: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
-    entries: PropTypes.array.isRequired,
+    entries: PropTypes.arrayOf(PropTypes.string).isRequired, // Expecting array of entry IDs
   }).isRequired,
   onDropEntry: PropTypes.func.isRequired,
 };

--- a/lune-interface/client/src/components/Folder.test.js
+++ b/lune-interface/client/src/components/Folder.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Folder from './Folder';
+
+// Mock useNavigate
+const mockedNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe('Folder Component', () => {
+  const mockFolderData = {
+    id: 'folder123',
+    name: 'My Test Folder',
+    entries: ['entry1', 'entry2'], // Array of entry IDs
+  };
+  const mockOnDropEntry = jest.fn();
+
+  beforeEach(() => {
+    // Clear mock call history before each test
+    mockedNavigate.mockClear();
+    mockOnDropEntry.mockClear();
+  });
+
+  test('renders folder name and entry count', () => {
+    render(
+      <MemoryRouter>
+        <Folder folder={mockFolderData} onDropEntry={mockOnDropEntry} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(mockFolderData.name)).toBeInTheDocument();
+    expect(screen.getByText(`(${mockFolderData.entries.length})`)).toBeInTheDocument();
+  });
+
+  test('navigates to folder view on click', () => {
+    render(
+      <MemoryRouter>
+        <Folder folder={mockFolderData} onDropEntry={mockOnDropEntry} />
+      </MemoryRouter>
+    );
+
+    const folderElement = screen.getByText(mockFolderData.name).closest('div');
+    fireEvent.click(folderElement);
+
+    expect(mockedNavigate).toHaveBeenCalledWith(`/folders/${mockFolderData.id}`);
+  });
+
+  test('displays correct entry count for zero entries', () => {
+    const folderWithNoEntries = { ...mockFolderData, entries: [] };
+    render(
+      <MemoryRouter>
+        <Folder folder={folderWithNoEntries} onDropEntry={mockOnDropEntry} />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('(0)')).toBeInTheDocument();
+  });
+
+  // Drag and drop is harder to test with precision without more complex setup
+  // but we can check if the handlers are present or try a basic fireEvent if needed.
+  // For now, focusing on rendering and navigation.
+
+  test('has correct title attribute', () => {
+    render(
+      <MemoryRouter>
+        <Folder folder={mockFolderData} onDropEntry={mockOnDropEntry} />
+      </MemoryRouter>
+    );
+    const folderElement = screen.getByText(mockFolderData.name).closest('div');
+    expect(folderElement).toHaveAttribute(
+      'title',
+      `Open folder: ${mockFolderData.name} (${mockFolderData.entries.length} entries)`
+    );
+  });
+});

--- a/lune-interface/client/src/components/FolderViewPage.js
+++ b/lune-interface/client/src/components/FolderViewPage.js
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+
+export default function FolderViewPage({ allEntries, allFolders, startEdit, refreshEntries }) {
+  const { folderId } = useParams();
+  const navigate = useNavigate();
+  const [currentFolder, setCurrentFolder] = useState(null);
+  const [entriesInFolder, setEntriesInFolder] = useState([]);
+
+  useEffect(() => {
+    if (allFolders && allEntries && folderId) {
+      const folder = allFolders.find(f => f.id === folderId);
+      if (folder) {
+        setCurrentFolder(folder);
+        const filteredEntries = allEntries.filter(entry => entry.folderId === folderId)
+          .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp)); // Sort newest first
+        setEntriesInFolder(filteredEntries);
+      } else {
+        // Folder not found, maybe navigate to a 404 page or back to entries
+        console.warn(`Folder with ID ${folderId} not found.`);
+        navigate('/entries'); // Or a dedicated 404 page
+      }
+    }
+  }, [folderId, allEntries, allFolders, navigate]);
+
+  const handleDelete = async (entryId) => {
+    if (!window.confirm('Delete this entry?')) return;
+    await fetch(`/diary/${entryId}`, { method: 'DELETE' });
+    // Refresh entries at the App level or however refreshEntries is implemented
+    if (refreshEntries) {
+        await refreshEntries();
+    }
+    // No need to manually filter here if allEntries prop updates, useEffect will handle it.
+  };
+
+  if (!currentFolder) {
+    // Could show a loading indicator or a "Folder not found" message
+    return <div className="p-4 text-center">Loading folder details or folder not found...</div>;
+  }
+
+  return (
+    <div className="p-4 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-lunePurple text-3xl font-bold font-literata">
+          Folder: {currentFolder.name}
+        </h1>
+        <Link to="/entries" className="text-lunePurple underline hover:text-luneGold">
+          Back to All Entries
+        </Link>
+      </div>
+
+      <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f]">
+        {entriesInFolder.length > 0 ? (
+          entriesInFolder.map(entry => (
+            <div
+              key={entry.id}
+              className="rounded-xl bg-gradient-to-b from-slate-800/30 to-slate-900/60 p-4 shadow-md backdrop-blur-md cursor-pointer hover:shadow-[0_0_12px_#fcd34d80] hover:scale-[1.02] focus:scale-[1.02] transition-transform duration-500 ease-in-out"
+              onClick={() => { startEdit(entry.id); navigate('/chat'); }}
+            >
+              <div className="text-xs text-slate-400 italic tracking-wide font-ibmPlexMono uppercase">
+                {new Date(entry.timestamp).toLocaleString()}
+              </div>
+              <div className="whitespace-pre-wrap mb-2">{entry.text}</div>
+              {entry.agent_logs?.Lune && (
+                <div className="mb-2 p-2 bg-luneGray rounded">
+                  <span className="font-semibold">Lune:</span> {entry.agent_logs.Lune.reflection}
+                </div>
+              )}
+              <button
+                onClick={(e) => { e.stopPropagation(); handleDelete(entry.id); }}
+                className="text-sm text-red-600 hover:text-red-400"
+              >
+                Delete
+              </button>
+            </div>
+          ))
+        ) : (
+          <div className="text-center text-luneDarkGray p-5">This folder is empty.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+FolderViewPage.propTypes = {
+  allEntries: PropTypes.array.isRequired,
+  allFolders: PropTypes.array.isRequired,
+  startEdit: PropTypes.func.isRequired,
+  refreshEntries: PropTypes.func, // Optional, but good for consistency
+};

--- a/lune-interface/client/src/components/FolderViewPage.test.js
+++ b/lune-interface/client/src/components/FolderViewPage.test.js
@@ -1,0 +1,166 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import FolderViewPage from './FolderViewPage';
+
+// Mock react-router-dom hooks
+const mockedNavigate = jest.fn();
+let mockParams = { folderId: 'folder1' };
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate,
+  useParams: () => mockParams,
+  Link: ({ children, to }) => <a href={to}>{children}</a>, // Simple mock for Link
+}));
+
+describe('FolderViewPage Component', () => {
+  const mockAllEntries = [
+    { id: 'entry1', text: 'Entry 1 in Folder 1', folderId: 'folder1', timestamp: new Date().toISOString(), agent_logs: {} },
+    { id: 'entry2', text: 'Entry 2 in Folder 1', folderId: 'folder1', timestamp: new Date().toISOString(), agent_logs: {} },
+    { id: 'entry3', text: 'Entry in Another Folder', folderId: 'folder2', timestamp: new Date().toISOString(), agent_logs: {} },
+    { id: 'entry4', text: 'Unfiled Entry', folderId: null, timestamp: new Date().toISOString(), agent_logs: {} },
+  ];
+
+  const mockAllFolders = [
+    { id: 'folder1', name: 'Test Folder One' },
+    { id: 'folder2', name: 'Test Folder Two' },
+  ];
+
+  const mockStartEdit = jest.fn();
+  const mockRefreshEntries = jest.fn();
+
+  const renderComponent = (currentParams = { folderId: 'folder1' }) => {
+    mockParams = currentParams; // Update mockParams before render
+    return render(
+      <MemoryRouter initialEntries={[`/folders/${currentParams.folderId}`]}>
+        <Routes>
+          <Route
+            path="/folders/:folderId"
+            element={
+              <FolderViewPage
+                allEntries={mockAllEntries}
+                allFolders={mockAllFolders}
+                startEdit={mockStartEdit}
+                refreshEntries={mockRefreshEntries}
+              />
+            }
+          />
+          <Route path="/entries" element={<div>All Entries Page</div>} />
+          <Route path="/chat" element={<div>Chat Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+
+  beforeEach(() => {
+    mockedNavigate.mockClear();
+    mockStartEdit.mockClear();
+    mockRefreshEntries.mockClear();
+  });
+
+  test('renders folder name and its entries', () => {
+    renderComponent();
+    expect(screen.getByText(`Folder: ${mockAllFolders[0].name}`)).toBeInTheDocument();
+    expect(screen.getByText('Entry 1 in Folder 1')).toBeInTheDocument();
+    expect(screen.getByText('Entry 2 in Folder 1')).toBeInTheDocument();
+    expect(screen.queryByText('Entry in Another Folder')).not.toBeInTheDocument();
+    expect(screen.queryByText('Unfiled Entry')).not.toBeInTheDocument();
+  });
+
+  test('displays "folder is empty" message if no entries belong to the folder', () => {
+    renderComponent({ folderId: 'folder2' }); // folder2 has one entry by mockAllEntries setup, let's change that for the test
+
+    const entriesForFolder2Only = [ // Override mockAllEntries for this specific test case
+        { id: 'entry3', text: 'Entry in Another Folder', folderId: 'folder2', timestamp: new Date().toISOString(), agent_logs: {} },
+    ];
+    const foldersForFolder2Only = [mockAllFolders[1]];
+
+    mockParams = { folderId: 'folder2' }; // Ensure params are set for this specific render
+    render(
+        <MemoryRouter initialEntries={[`/folders/folder2`]}>
+          <Routes>
+            <Route
+              path="/folders/:folderId"
+              element={
+                <FolderViewPage
+                  allEntries={mockAllEntries.filter(e => e.id !== 'entry1' && e.id !== 'entry2')} // Remove folder1 entries
+                  allFolders={mockAllFolders} // Keep all folders for lookup
+                  startEdit={mockStartEdit}
+                  refreshEntries={mockRefreshEntries}
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+    // Re-render with specific empty folder scenario
+    const folderWithNoEntries = { id: 'folder3', name: 'Empty Folder' };
+    mockParams = { folderId: 'folder3' };
+    render(
+      <MemoryRouter initialEntries={['/folders/folder3']}>
+        <Routes>
+            <Route path="/folders/:folderId" element={
+                <FolderViewPage
+                    allEntries={mockAllEntries}
+                    allFolders={[...mockAllFolders, folderWithNoEntries]}
+                    startEdit={mockStartEdit}
+                    refreshEntries={mockRefreshEntries}
+                />}
+            />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(`Folder: ${folderWithNoEntries.name}`)).toBeInTheDocument();
+    expect(screen.getByText('This folder is empty.')).toBeInTheDocument();
+  });
+
+  test('navigates to chat page on entry click', () => {
+    renderComponent();
+    const entryElement = screen.getByText('Entry 1 in Folder 1');
+    fireEvent.click(entryElement);
+    expect(mockStartEdit).toHaveBeenCalledWith('entry1');
+    expect(mockedNavigate).toHaveBeenCalledWith('/chat');
+  });
+
+  test('navigates to /entries on "Back to All Entries" link click', () => {
+    renderComponent();
+    // Since Link is mocked as a simple <a>, we find by text and check href or simulate click
+    const backLink = screen.getByText('Back to All Entries');
+    expect(backLink).toHaveAttribute('href', '/entries');
+    // To test navigation with mocked Link, usually you'd check mockedNavigate
+    // For a simple href check, this is fine. If actual navigation needs testing:
+    // fireEvent.click(backLink);
+    // expect(mockedNavigate).toHaveBeenCalledWith('/entries'); // This depends on how Link mock interacts
+  });
+
+  test('handles folder not found by navigating to /entries', async () => {
+    renderComponent({ folderId: 'nonexistentfolder' });
+    // It should navigate away. Check if the "Loading" or "not found" text briefly appears,
+    // then navigation occurs. useNavigate is called within useEffect.
+    await waitFor(() => {
+      expect(mockedNavigate).toHaveBeenCalledWith('/entries');
+    });
+  });
+
+  // Test for delete button (optional, as it's similar to EntriesPage)
+  test('calls handleDelete and refreshes entries on delete button click', async () => {
+    window.confirm = jest.fn(() => true); // Mock window.confirm
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ message: 'Deleted' }),
+      })
+    );
+
+    renderComponent();
+    const deleteButtons = screen.getAllByText('Delete'); // Assuming 'Delete' is unique enough
+    fireEvent.click(deleteButtons[0]); // Click the first delete button
+
+    expect(window.confirm).toHaveBeenCalledWith('Delete this entry?');
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('/diary/entry1', { method: 'DELETE' }));
+    await waitFor(() => expect(mockRefreshEntries).toHaveBeenCalled());
+
+    jest.restoreAllMocks(); // Restore fetch and confirm
+  });
+});


### PR DESCRIPTION
Implemented navigation to a dedicated page for each folder, allowing users to view entries contained within a specific folder.

Frontend (React):
- Modified `Folder.js`:
    - Made folder bubbles clickable.
    - On click, navigates to a new route `/folders/:folderId`.
    - Updated visual feedback (entry count, title).
- Created `FolderViewPage.js`:
    - Displays the name of the selected folder.
    - Fetches and lists only the entries belonging to that folder.
    - Entries are clickable for editing (navigates to chat view).
    - Includes a "Back to All Entries" link.
- Updated `App.js`:
    - Added a new route `/folders/:folderId` rendering `FolderViewPage`.
    - Manages fetching and state for both entries and folders, passing them as props.
    - Implemented `refreshAllData` to refresh both entries and folders.
- Updated `EntriesPage.js`:
    - Now uses global `folders` state from `App.js`.
    - `handleAddFolder` calls backend API to create folder and refreshes global state.
    - `handleDropEntryIntoFolder` calls backend API to update entry's folderId and refreshes.
- Tests:
    - Added tests for `Folder.js` to verify rendering and navigation on click.
    - Added tests for `FolderViewPage.js` to verify:
        - Correct display of folder name and filtered entries.
        - Navigation for entry clicks and "Back" link. - Behavior with empty folders and invalid folder IDs. - Entry deletion within the folder view.
    - Utilized React Testing Library and Jest for frontend tests.

This enhancement allows users to open folders and view their contents on a separate page, improving organization and usability.