### PR TITLE
Remove scrollbars on diary entry lists

### DIFF
--- a/lune-interface/client/src/components/EntriesMenu.js
+++ b/lune-interface/client/src/components/EntriesMenu.js
@@ -28,7 +28,7 @@ function EntriesMenu({ entries, onSelect, onNew }) {
           New Entry
         </button>
       </div>
-      <div className="overflow-y-auto max-h-[70vh]">
+      <div className="overflow-y-auto max-h-[70vh] no-scrollbar">
         {filtered.map(entry => (
           <div
             key={entry._id || entry.id || Math.random()}

--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -106,7 +106,7 @@ export default function EntriesPage({ entries, folders, refreshEntries, refreshF
       )}
 
       {/* Entries Section */}
-      <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f]">
+      <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f] no-scrollbar">
         {unfiledEntries.map(entry => (
           <div
             key={entry.id}

--- a/lune-interface/client/src/components/FolderViewPage.js
+++ b/lune-interface/client/src/components/FolderViewPage.js
@@ -50,7 +50,7 @@ export default function FolderViewPage({ allEntries, allFolders, startEdit, refr
         </Link>
       </div>
 
-      <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f]">
+      <div className="space-y-4 mb-4 max-h-[70vh] overflow-y-auto ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f] no-scrollbar">
         {entriesInFolder.length > 0 ? (
           entriesInFolder.map(entry => (
             <div

--- a/lune-interface/client/src/components/LuneChatModal.js
+++ b/lune-interface/client/src/components/LuneChatModal.js
@@ -77,7 +77,7 @@ export default function LuneChatModal({ open, onClose }) {
           <h2 className="font-bold text-xl text-lunePurple font-literata">Chat with Lune</h2>
           <button onClick={handleClose} className="text-lunePurple font-bold text-2xl">&times;</button>
         </div>
-        <div className="flex-1 overflow-y-auto mb-4 space-y-2 max-h-80 border rounded p-2 bg-luneGray/30 ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f]">
+        <div className="flex-1 overflow-y-auto mb-4 space-y-2 max-h-80 border rounded p-2 bg-luneGray/30 ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f] no-scrollbar">
           {messages.map((msg, i) => (
             <div
               key={i}

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -12,6 +12,15 @@ body {
 @tailwind components;
 @tailwind utilities;
 
+/* Utility to hide scrollbars while preserving scroll ability */
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.no-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
 @keyframes fadeIn {
   to {
     opacity: 1;


### PR DESCRIPTION
## Summary
- hide scrollbars with new `.no-scrollbar` CSS utility
- apply scrollbar hiding to diary entry containers and chat modal

## Testing
- `npm test --prefix lune-interface/server` *(fails: ReferenceError: describe is not defined)*
- `npm test --prefix lune-interface/client --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_686cb4c8e5508327ae52fed2bb29beea