### PR TITLE
feat: Add global JSON error and 404 handlers to server

### DIFF
--- a/lune-interface/server/server.js
+++ b/lune-interface/server/server.js
@@ -37,4 +37,26 @@ if (require.main === module) {
   });
 }
 
+// --- 404 Handler (Not Found) ---
+// This middleware should be placed after all your routes
+app.use((req, res, next) => {
+  res.status(404).json({ error: `Not Found - ${req.method} ${req.originalUrl}` });
+});
+
+// --- Global Error Handler ---
+// This middleware should be the last one.
+// Express recognizes it as an error handler by its four arguments.
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
+  console.error('Global error handler caught:', err);
+  // Set a default status code if not already set (e.g., from an error object)
+  const statusCode = err.statusCode || 500;
+  // Send a JSON response
+  res.status(statusCode).json({
+    error: err.message || 'An unexpected error occurred.',
+    // Optionally, include stack trace in development
+    ...(process.env.NODE_ENV === 'development' && { stack: err.stack }),
+  });
+});
+
 module.exports = app;


### PR DESCRIPTION
This change introduces two new middleware to the Express server:

1. A 404 handler that ensures requests to undefined routes return a JSON response with a 404 status.
2. A global error handler that catches any unhandled errors occurring in the application (e.g., errors passed via `next(err)` or synchronous errors in middleware/routes not caught locally). This handler ensures that a JSON response is sent to the client, typically with a 500 status, instead of Express's default HTML error page.

These handlers will prevent the client from receiving HTML when it expects JSON, thus resolving 'Unexpected token '<'' parsing errors when the server encounters issues like undefined routes or unhandled exceptions.