### PR TITLE
feat: Implement hashtag tagging system for diary entries

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -6,7 +6,8 @@ import FolderViewPage from './components/FolderViewPage'; // Import FolderViewPa
 
 function App() {
   const [entries, setEntries] = useState([]);
-  const [folders, setFolders] = useState([]); // Add state for folders
+  const [folders, setFolders] = useState([]);
+  const [hashtags, setHashtags] = useState([]); // Add state for hashtags
   const [editingId, setEditingId] = useState(null);
 
   // Fetch entries from backend
@@ -35,17 +36,32 @@ function App() {
     }
   }, []);
 
-  // Initial load for entries and folders
+  // Fetch hashtags from backend
+  const fetchHashtags = useCallback(async () => {
+    try {
+      const res = await fetch('/diary/hashtags');
+      if (!res.ok) throw new Error(`Failed to fetch hashtags: ${res.status}`);
+      const data = await res.json();
+      setHashtags(data);
+    } catch (error) {
+      console.error("Error fetching hashtags:", error);
+      setHashtags([]); // Set to empty array on error
+    }
+  }, []);
+
+  // Initial load for entries, folders, and hashtags
   useEffect(() => {
     fetchEntries();
     fetchFolders();
-  }, [fetchEntries, fetchFolders]);
+    fetchHashtags();
+  }, [fetchEntries, fetchFolders, fetchHashtags]);
 
   // Combined refresh function
   const refreshAllData = useCallback(async () => {
     await fetchEntries();
     await fetchFolders();
-  }, [fetchEntries, fetchFolders]);
+    await fetchHashtags();
+  }, [fetchEntries, fetchFolders, fetchHashtags]);
 
   return (
     <Router>
@@ -55,7 +71,8 @@ function App() {
           element={
             <DockChat
               entries={entries}
-              refreshEntries={refreshAllData} // Use combined refresh
+              hashtags={hashtags} // Pass hashtags
+              refreshEntries={refreshAllData} // Use combined refresh (now includes hashtags)
               editingId={editingId}
               setEditingId={setEditingId}
             />

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -2,11 +2,15 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import LuneChatModal from './LuneChatModal';
+import HashtagButtons from './HashtagButtons';
+import HashtagEntriesModal from './HashtagEntriesModal'; // Import HashtagEntriesModal
 
-export default function DockChat({ entries, refreshEntries, editingId, setEditingId }) {
+export default function DockChat({ entries, hashtags, refreshEntries, editingId, setEditingId }) {
   const [input, setInput] = useState('');
   const [editing, setEditing] = useState(null);
   const [showChat, setShowChat] = useState(false);
+  const [isHashtagModalOpen, setIsHashtagModalOpen] = useState(false); // State for hashtag modal
+  const [selectedHashtag, setSelectedHashtag] = useState(null); // State for selected hashtag
   const fileInputRef = useRef(null);
   const navigate = useNavigate();
 
@@ -72,6 +76,11 @@ export default function DockChat({ entries, refreshEntries, editingId, setEditin
     e.target.value = '';
   };
 
+  const handleHashtagButtonClick = (tag) => {
+    setSelectedHashtag(tag);
+    setIsHashtagModalOpen(true);
+  };
+
   // const startEdit = (id) => setEditing(id);
 
   return (
@@ -100,6 +109,9 @@ export default function DockChat({ entries, refreshEntries, editingId, setEditin
           className="hidden"
         />
       </div>
+      {/* Hashtag Buttons Area */}
+      <HashtagButtons hashtags={hashtags} onHashtagClick={handleHashtagButtonClick} />
+
       <form onSubmit={handleSubmit} className="flex gap-2">
         <textarea
           className={`flex-1 border rounded p-2 ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f] text-[#f8f8f2] ${input.trim() ? 'animate-pulse' : ''}`}
@@ -112,13 +124,24 @@ export default function DockChat({ entries, refreshEntries, editingId, setEditin
       {input.trim() && <div className="w-full h-[2px] bg-indigo-500/30 mt-1"></div>}
       <button onClick={() => navigate('/entries')} className="mt-4 text-lunePurple underline">Go to Entries</button>
       <LuneChatModal open={showChat} onClose={() => setShowChat(false)} />
+      <HashtagEntriesModal
+        isOpen={isHashtagModalOpen}
+        onClose={() => setIsHashtagModalOpen(false)}
+        hashtag={selectedHashtag}
+        entries={entries} // Pass all entries
+        onSelectEntry={(entryId) => {
+          if (setEditingId) setEditingId(entryId); // Ensure setEditingId is callable
+          setIsHashtagModalOpen(false);
+        }}
+      />
     </div>
   );
 }
 
 DockChat.propTypes = {
   entries: PropTypes.array.isRequired,
+  hashtags: PropTypes.arrayOf(PropTypes.string).isRequired,
   refreshEntries: PropTypes.func.isRequired,
-  editingId: PropTypes.any,
-  setEditingId: PropTypes.func,
+  editingId: PropTypes.any, // Can be null or string
+  setEditingId: PropTypes.func, // Can be undefined if not passed from a route that supports editing
 };

--- a/lune-interface/client/src/components/HashtagButtons.js
+++ b/lune-interface/client/src/components/HashtagButtons.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function HashtagButtons({ hashtags, onHashtagClick }) {
+  if (!hashtags || hashtags.length === 0) {
+    return null; // Don't render anything if there are no hashtags
+  }
+
+  return (
+    <div className="mb-2 flex flex-wrap gap-2">
+      {hashtags.map((tag) => (
+        <button
+          key={tag}
+          type="button" // Important to prevent form submission if inside a form
+          onClick={() => onHashtagClick(tag)}
+          className="px-3 py-1 bg-luneSecondary text-luneText rounded-full text-sm hover:bg-lunePurple focus:outline-none focus:ring-2 focus:ring-lunePurple-dark focus:ring-opacity-50 transition-colors duration-150"
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+HashtagButtons.propTypes = {
+  hashtags: PropTypes.arrayOf(PropTypes.string).isRequired,
+  onHashtagClick: PropTypes.func.isRequired,
+};
+
+export default HashtagButtons;

--- a/lune-interface/client/src/components/HashtagEntriesModal.js
+++ b/lune-interface/client/src/components/HashtagEntriesModal.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function HashtagEntriesModal({ isOpen, onClose, hashtag, entries, onSelectEntry }) {
+  if (!isOpen || !hashtag) {
+    return null;
+  }
+
+  const filteredEntries = entries.filter(entry => entry.hashtags && entry.hashtags.includes(hashtag));
+
+  // Simple function to get a snippet of text
+  const getSnippet = (text, maxLength = 100) => {
+    if (!text) return '';
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength) + '...';
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex justify-center items-center z-50 p-4">
+      <div className="bg-slate-800 p-6 rounded-lg shadow-xl max-w-lg w-full max-h-[80vh] flex flex-col">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-2xl font-semibold text-lunePurple font-literata">
+            Entries for <span className="text-luneGold">{hashtag}</span>
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-luneLightGray hover:text-white text-2xl font-bold"
+            aria-label="Close modal"
+          >
+            &times;
+          </button>
+        </div>
+
+        {filteredEntries.length > 0 ? (
+          <ul className="space-y-3 overflow-y-auto no-scrollbar flex-grow">
+            {filteredEntries.map((entry) => (
+              <li key={entry.id}>
+                <button
+                  onClick={() => {
+                    onSelectEntry(entry.id);
+                    onClose();
+                  }}
+                  className="w-full text-left p-3 bg-slate-700 hover:bg-lunePurple/30 rounded-md transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-lunePurple"
+                >
+                  <p className="text-sm text-slate-300 mb-1">
+                    {new Date(entry.timestamp).toLocaleString()}
+                  </p>
+                  <p className="text-luneText">{getSnippet(entry.text)}</p>
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-luneDarkGray text-center py-4">No entries found for this hashtag.</p>
+        )}
+
+        <button
+            onClick={onClose}
+            className="mt-6 bg-luneRed hover:bg-red-700 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-150 self-center"
+        >
+            Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+HashtagEntriesModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  hashtag: PropTypes.string,
+  entries: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    timestamp: PropTypes.string.isRequired,
+    hashtags: PropTypes.arrayOf(PropTypes.string),
+  })).isRequired,
+  onSelectEntry: PropTypes.func.isRequired,
+};
+
+export default HashtagEntriesModal;

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -140,4 +140,16 @@ router.delete('/folders/:id', async (req, res) => {
   }
 });
 
+// --- Hashtag Routes ---
+
+// Get all unique hashtags
+router.get('/hashtags', async (req, res) => {
+  try {
+    const hashtags = await diaryStore.getAllUniqueHashtags();
+    res.json(hashtags);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
This commit introduces a comprehensive hashtag tagging system:

Backend:
- Modified `diaryStore.js` to parse and store `#tag` style hashtags in a new `hashtags` array within each diary entry object.
- Added a new route `GET /diary/hashtags` in `routes/diary.js` to retrieve a unique, sorted list of all hashtags from diary entries.

Frontend:
- Updated `App.js` to fetch and manage the global list of unique hashtags.
- Created `HashtagButtons.js` component to display these unique hashtags as clickable buttons above the diary input area in `DockChat.js`. Buttons have hover effects.
- Implemented `HashtagEntriesModal.js`, a modal component that appears when a hashtag button is clicked.
- The modal displays a list of all diary entries associated with the selected hashtag.
- Entries in the modal are presented as clickable items (showing timestamp and text snippet) that, when clicked, populate the main diary input for viewing/editing and close the modal.
- `DockChat.js` now integrates `HashtagButtons` and manages the display and state of `HashtagEntriesModal`.

Styling for new components is done using Tailwind CSS for a consistent UI.