### PR TITLE
Refactor: Remove Upload button and reposition Chat with Lune button

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -3,12 +3,14 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import DockChat from './components/DockChat';
 import EntriesPage from './components/EntriesPage';
 import FolderViewPage from './components/FolderViewPage'; // Import FolderViewPage
+import LuneChatModal from './components/LuneChatModal'; // Import LuneChatModal
 
 function App() {
   const [entries, setEntries] = useState([]);
   const [folders, setFolders] = useState([]);
   const [hashtags, setHashtags] = useState([]); // Add state for hashtags
   const [editingId, setEditingId] = useState(null);
+  const [showChat, setShowChat] = useState(false); // Add showChat state
 
   // Fetch entries from backend
   const fetchEntries = useCallback(async () => {
@@ -65,9 +67,11 @@ function App() {
 
   return (
     <Router>
-      <Routes>
-        <Route
-          path="/chat"
+      <div className="flex flex-col min-h-screen">
+        <div className="flex-grow">
+          <Routes>
+            <Route
+              path="/chat"
           element={
             <DockChat
               entries={entries}
@@ -104,6 +108,18 @@ function App() {
         />
         <Route path="*" element={<Navigate to="/chat" replace />} />
       </Routes>
+        </div>
+        <footer className="w-full flex justify-center items-center p-4">
+          <button
+            type="button"
+            onClick={() => setShowChat(true)} // Use setShowChat from App's state
+            className="bg-lunePurple text-white px-4 py-2 rounded"
+          >
+            Chat with Lune
+          </button>
+        </footer>
+        <LuneChatModal open={showChat} onClose={() => setShowChat(false)} />
+      </div>
     </Router>
   );
 }

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react'; // Removed useRef
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
-import LuneChatModal from './LuneChatModal';
+// LuneChatModal is now imported in App.js
 import HashtagButtons from './HashtagButtons';
 import HashtagEntriesModal from './HashtagEntriesModal'; // Import HashtagEntriesModal
 import DiaryInput from "./DiaryInput"; // Back to relative path
@@ -9,10 +9,9 @@ import DiaryInput from "./DiaryInput"; // Back to relative path
 export default function DockChat({ entries, hashtags, refreshEntries, editingId, setEditingId }) {
   const [input, setInput] = useState(''); // This state will be managed by DiaryInput, but handleSubmit logic relies on it. Consider refactoring.
   const [editing, setEditing] = useState(null);
-  const [showChat, setShowChat] = useState(false);
+  // const [showChat, setShowChat] = useState(false); // Moved to App.js
   const [isHashtagModalOpen, setIsHashtagModalOpen] = useState(false); // State for hashtag modal
   const [selectedHashtag, setSelectedHashtag] = useState(null); // State for selected hashtag
-  const fileInputRef = useRef(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -63,33 +62,6 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
     // await handleSave(input); // This `input` is the old state variable
   };
 
-  const handleUpload = async (e) => {
-    const file = e.target.files && e.target.files[0];
-    if (!file) return;
-    try {
-      const text = await file.text();
-      const data = JSON.parse(text);
-      if (Array.isArray(data)) {
-        for (const entry of data) {
-          const bodyText = entry.text || entry.content;
-          if (typeof bodyText === 'string') {
-            await fetch('/diary', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ text: bodyText })
-            });
-          }
-        }
-        await refreshEntries();
-      } else {
-        alert('Invalid diary JSON.');
-      }
-    } catch (err) {
-      alert('Failed to import diary: ' + err.message);
-    }
-    e.target.value = '';
-  };
-
   const handleHashtagButtonClick = (tag) => {
     setSelectedHashtag(tag);
     setIsHashtagModalOpen(true);
@@ -101,27 +73,6 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
     <div className="p-4 bg-gradient-to-br from-slate-900 via-zinc-900 to-slate-950 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
       <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center font-literata">Lune Diary.</h1>
       <div className="flex gap-2 mb-4">
-        <button
-          type="button"
-          onClick={() => setShowChat(true)}
-          className="bg-lunePurple text-white px-4 py-2 rounded flex-1"
-        >
-          Chat with Lune
-        </button>
-        <button
-          type="button"
-          onClick={() => fileInputRef.current && fileInputRef.current.click()}
-          className="bg-lunePurple text-white px-4 py-2 rounded flex-1"
-        >
-          Upload
-        </button>
-        <input
-          type="file"
-          accept="application/json"
-          ref={fileInputRef}
-          onChange={handleUpload}
-          className="hidden"
-        />
       </div>
       {/* Hashtag Buttons Area */}
       <HashtagButtons hashtags={hashtags} onHashtagClick={handleHashtagButtonClick} />
@@ -133,7 +84,7 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
       {/* The visual pulse line below the input might need reconsideration as DiaryInput has its own structure */}
       {/* {input.trim() && <div className="w-full h-[2px] bg-indigo-500/30 mt-1"></div>} */}
       <button onClick={() => navigate('/entries')} className="mt-4 text-lunePurple underline">Go to Entries</button>
-      <LuneChatModal open={showChat} onClose={() => setShowChat(false)} />
+      {/* LuneChatModal is now rendered in App.js */}
       <HashtagEntriesModal
         isOpen={isHashtagModalOpen}
         onClose={() => setIsHashtagModalOpen(false)}


### PR DESCRIPTION
- Removed the 'Upload' button, its handler, and related elements from DockChat.js.
- Relocated the 'Chat with Lune' button from DockChat.js to a new footer in App.js.
- The new footer is full-width, with the button centered and retaining its original style and functionality.
- Adjusted state management for the LuneChatModal, moving state and modal rendering to App.js.