### PR TITLE
feat: Add mirrored top/bottom background gradients

### DIFF
--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -36,6 +36,7 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --violet: #6B46C1; /* Added for background gradient */
 }
 
 .dark {
@@ -129,7 +130,7 @@
 
 /* Original app styles */
 html {
-  background-color: #0d0d0f;
+  background-image: linear-gradient(to bottom, var(--violet) 0%, transparent 33%), linear-gradient(to top, var(--violet) 0%, transparent 33%), var(--background);
 }
 
 body {


### PR DESCRIPTION
- Defines a new CSS variable --violet (#6B46C1).
- Updates the global HTML background to use a dual linear-gradient for a mirrored violet-to-transparent effect on the top and bottom thirds.
- The middle third remains the original background color, ensuring content readability.