### PR TITLE
Apply ethereal UI enhancements

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -109,11 +109,11 @@ function App() {
         <Route path="*" element={<Navigate to="/chat" replace />} />
       </Routes>
         </div>
-        <footer className="w-full flex justify-center items-center p-4">
+        <footer className="w-full flex justify-center items-center px-4 pb-10 bg-white/5 backdrop-blur">
           <button
             type="button"
             onClick={() => setShowChat(true)} // Use setShowChat from App's state
-            className="bg-lunePurple text-white px-4 py-2 rounded"
+            className="px-4 py-2 rounded shadow-md shadow-violet-800/40"
           >
             Chat with Lune
           </button>

--- a/lune-interface/client/src/components/DiaryInput.jsx
+++ b/lune-interface/client/src/components/DiaryInput.jsx
@@ -60,10 +60,10 @@ const DiaryInput = ({ onSave, initialText = '', clearOnSave = false }) => {
         value={text}
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}
-        className="w-full min-h-[8rem] resize-none overflow-hidden rounded-2xl bg-white/5 backdrop-blur-md p-4 md:p-6 text-lg leading-relaxed text-slate-100 placeholder:text-slate-400 outline-none ring-1 ring-inset ring-white/10 focus:ring-2 focus:ring-violet-400 transition"
+        className="w-full min-h-[8rem] resize-none overflow-hidden rounded-2xl bg-white/5 backdrop-blur-md p-4 md:p-6 text-lg leading-loose text-slate-100 placeholder:text-slate-400 outline-none ring-1 ring-inset ring-white/5 focus:ring-2 focus:ring-violet-300/60 transition shadow-[0_6px_30px_-12px_rgb(91_33_182/0.3)]"
       />
-      <div className="mt-2 flex items-center justify-between">
-        <span className="text-xs text-slate-500">
+      <div className="mt-8 flex items-center justify-between">
+        <span className="text-xs text-slate-300">
           {wordCount} word{wordCount === 1 ? '' : 's'}
         </span>
         <Button

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -69,16 +69,19 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
 
   // const startEdit = (id) => setEditing(id);
 
+  // Calculate margin for the form based on whether hashtags are present
+  const formMarginTop = (hashtags && hashtags.length > 0) ? "mt-16" : "mt-20"; // mt-16 (4rem) if hashtags, mt-20 (5rem) if not. h1 has mb-4. HashtagButtons div has mb-4. Total mt-24 from h1.
+
   return (
     <div className="p-4 bg-gradient-to-br from-slate-900 via-zinc-900 to-slate-950 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
-      <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center font-literata">Lune Diary.</h1>
+      <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center font-literata font-light">Lune Diary.</h1>
       <div className="flex gap-2 mb-4">
       </div>
       {/* Hashtag Buttons Area */}
       <HashtagButtons hashtags={hashtags} onHashtagClick={handleHashtagButtonClick} />
 
       {/* The form tag is kept for structure but onSubmit might need adjustment if it's meant to trigger save from DiaryInput */}
-      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+      <form onSubmit={handleSubmit} className={`flex flex-col gap-2 ${formMarginTop}`}>
         <DiaryInput onSave={handleSave} initialText={input} clearOnSave={true} />
       </form>
       {/* The visual pulse line below the input might need reconsideration as DiaryInput has its own structure */}

--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -75,7 +75,7 @@ export default function EntriesPage({ entries, folders, refreshEntries, refreshF
   return (
     <div className="p-4 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
       <div className="flex justify-between items-center mb-4">
-        <h1 className="text-lunePurple text-3xl font-bold text-center font-literata">Entries</h1>
+        <h1 className="text-lunePurple text-3xl font-bold text-center font-literata font-light">Entries</h1>
         <button
           onClick={handleAddFolder}
           className="bg-lunePurple text-white font-bold py-2 px-4 rounded-lg shadow-md hover:bg-lunePurple-dark transition-colors duration-300"
@@ -87,7 +87,7 @@ export default function EntriesPage({ entries, folders, refreshEntries, refreshF
       {/* Folders Section */}
       {folders.length > 0 && (
         <div className="mb-6">
-          <h2 className="text-xl text-luneLightGray font-semibold mb-3 font-literata">Folders</h2>
+          <h2 className="text-xl text-luneLightGray mb-3 font-literata font-light">Folders</h2>
           <div className="flex flex-wrap gap-4 p-2 bg-[#0d0d0f]/50 rounded-lg shadow-inner">
             {folders.map(folder => (
               <Folder
@@ -115,7 +115,7 @@ export default function EntriesPage({ entries, folders, refreshEntries, refreshF
             className="rounded-xl bg-gradient-to-b from-slate-800/30 to-slate-900/60 p-4 shadow-md backdrop-blur-md cursor-grab hover:shadow-[0_0_12px_#fcd34d80] hover:scale-[1.02] focus:scale-[1.02] transition-transform duration-500 ease-in-out"
             onClick={() => { startEdit(entry.id); navigate('/chat'); }}
           >
-            <div className="text-xs text-slate-400 italic tracking-wide font-ibmPlexMono uppercase">{new Date(entry.timestamp).toLocaleString()}</div>
+            <div className="text-xs text-slate-300 italic tracking-wide font-ibmPlexMono uppercase">{new Date(entry.timestamp).toLocaleString()}</div>
             <div className="whitespace-pre-wrap mb-2">{entry.text}</div>
             {entry.agent_logs?.Lune && (
               <div className="mb-2 p-2 bg-luneGray rounded">
@@ -130,8 +130,8 @@ export default function EntriesPage({ entries, folders, refreshEntries, refreshF
             </button>
           </div>
         ))}
-        {entries.length === 0 && <div className="text-center text-luneDarkGray">No entries.</div>}
-        {entries.length > 0 && unfiledEntries.length === 0 && folders.length === 0 && <div className="text-center text-luneDarkGray">All entries are in folders.</div>}
+        {entries.length === 0 && <div className="text-center text-slate-300">No entries.</div>}
+        {entries.length > 0 && unfiledEntries.length === 0 && folders.length === 0 && <div className="text-center text-slate-300">All entries are in folders.</div>}
       </div>
       <button onClick={() => navigate('/chat')} className="text-lunePurple underline">Back to Chat</button>
     </div>

--- a/lune-interface/client/src/components/FolderViewPage.js
+++ b/lune-interface/client/src/components/FolderViewPage.js
@@ -64,7 +64,7 @@ export default function FolderViewPage({ allEntries, allFolders, startEdit, refr
   return (
     <div className="p-4 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
       <div className="flex justify-between items-center mb-4">
-        <h1 className="text-lunePurple text-3xl font-bold font-literata">
+        <h1 className="text-lunePurple text-3xl font-bold font-literata font-light">
           Folder: {currentFolder.name}
         </h1>
         <Link to="/entries" className="text-lunePurple underline hover:text-luneGold">
@@ -80,7 +80,7 @@ export default function FolderViewPage({ allEntries, allFolders, startEdit, refr
               className="rounded-xl bg-gradient-to-b from-slate-800/30 to-slate-900/60 p-4 shadow-md backdrop-blur-md cursor-pointer hover:shadow-[0_0_12px_#fcd34d80] hover:scale-[1.02] focus:scale-[1.02] transition-transform duration-500 ease-in-out"
               onClick={() => { startEdit(entry.id); navigate('/chat'); }}
             >
-              <div className="text-xs text-slate-400 italic tracking-wide font-ibmPlexMono uppercase">
+              <div className="text-xs text-slate-300 italic tracking-wide font-ibmPlexMono uppercase">
                 {new Date(entry.timestamp).toLocaleString()}
               </div>
               <div className="whitespace-pre-wrap mb-2">{entry.text}</div>
@@ -106,7 +106,7 @@ export default function FolderViewPage({ allEntries, allFolders, startEdit, refr
             </div>
           ))
         ) : (
-          <div className="text-center text-luneDarkGray p-5">This folder is empty.</div>
+          <div className="text-center text-slate-300 p-5">This folder is empty.</div>
         )}
       </div>
     </div>

--- a/lune-interface/client/src/components/LuneChatModal.js
+++ b/lune-interface/client/src/components/LuneChatModal.js
@@ -74,7 +74,7 @@ export default function LuneChatModal({ open, onClose }) {
     <div className={`fixed inset-0 z-50 flex items-center justify-center bg-animaPink backdrop-blur-md transition-opacity duration-700 ease-in-out ${open ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
       <div className={`rounded-2xl shadow-xl max-w-lg w-full p-6 flex flex-col bg-gradient-to-br from-slate-900 via-zinc-900 to-slate-950 border-l-[1px] border-zinc-700/60 transition-all duration-700 ease-in-out transform ${open ? 'opacity-100 translate-y-0 translate-x-0' : 'opacity-0 translate-y-10 translate-x-10'}`}>
         <div className="flex justify-between items-center mb-2">
-          <h2 className="font-bold text-xl text-lunePurple font-literata">Chat with Lune</h2>
+          <h2 className="font-bold text-xl text-lunePurple font-literata font-light">Chat with Lune</h2>
           <button onClick={handleClose} className="text-lunePurple font-bold text-2xl">&times;</button>
         </div>
         <div className="flex-1 overflow-y-auto mb-4 space-y-2 max-h-80 border rounded p-2 bg-luneGray/30 ring-1 ring-slate-800 shadow-inner bg-[#0d0d0f] no-scrollbar">
@@ -87,12 +87,12 @@ export default function LuneChatModal({ open, onClose }) {
                   : 'italic bg-zinc-700/60 border border-indigo-800/20 backdrop-blur text-indigo-200 rounded-lg p-3 shadow-inner'
               }`}
             >
-              <span className="block text-xs">{msg.sender === 'user' ? 'You' : 'Lune'}</span>
+              <span className="block text-xs text-slate-300">{msg.sender === 'user' ? 'You' : 'Lune'}</span>
               {msg.text}
             </div>
           ))}
           {loading && (
-            <div className="flex items-center text-luneGray">
+            <div className="flex items-center text-slate-300">
               <div className="w-4 h-4 mr-2 border-2 border-lunePurple border-t-transparent rounded-full animate-spin"></div>
               Lune is thinking…
             </div>

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -3,7 +3,7 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: oklch(1 0 0);
+  --background: #070711; /* Deepest-navy base */
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -40,7 +40,7 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: #070711; /* Deepest-navy base */
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.145 0 0);
   --card-foreground: oklch(0.985 0 0);
@@ -137,9 +137,11 @@ body::before {
   inset: 0;                         /* cover entire viewport */
   background:
     /* top third */
-    linear-gradient(to bottom, var(--violet, #5b21b6) 0%, transparent 70%) top / 100% 33% no-repeat,
+    linear-gradient(to bottom, var(--violet, #5b21b64D) 0%, transparent 70%) top / 100% 33% no-repeat,
     /* bottom third */
-    linear-gradient(to top,   var(--violet, #5b21b6) 0%, transparent 70%) bottom / 100% 33% no-repeat;
+    linear-gradient(to top,   var(--violet, #5b21b64D) 0%, transparent 70%) bottom / 100% 33% no-repeat,
+    /* subtle radial halo */
+    radial-gradient(ellipse at 50% 350px, #5b21b6 15%, transparent 60%);
   pointer-events: none;             /* don’t block clicks */
   z-index: -1;                      /* sit behind everything */
 }


### PR DESCRIPTION
Full list of changes:

- Base Styles:
  - Body background to #070711.
  - body::before linear gradients to 30% opacity.
  - Added radial gradient to body::before for violet halo.
- Borders and Shadows:
  - Textarea ring to ring-white/5 and focus:ring-violet-300/60.
  - Textarea box-shadow to shadow-[0_6px_30px_-12px_rgb(91_33_182/0.3)].
- Footer and Button:
  - 'Chat with Lune' bar to bg-white/5 backdrop-blur.
  - Button shadow to shadow-violet-800/40, removed opaque background.
- Typography:
  - Headings (h1, h2) to font-light.
  - Tertiary text color to text-slate-300.
  - Textarea leading to leading-loose.
- Vertical Spacing:
  - mt-24 from header to textarea.
  - mt-8 from textarea to helper row.
  - Footer pb-10.