### PR TITLE
Refactor: Localize frost effect and remove global overlay

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -110,7 +110,7 @@ function App() {
       </Routes>
         </div>
         <footer className="w-full flex justify-center items-center px-4 pb-10">
-          <div className="rounded-2xl bg-white/6 backdrop-blur-lg px-6 py-3 shadow-[0_6px_18px_-6px_rgb(91_33_182/0.35)]">
+          <div className="frost rounded-2xl px-6 py-3">
             <button
               type="button"
               onClick={() => setShowChat(true)} // Use setShowChat from App's state

--- a/lune-interface/client/src/components/DiaryInput.jsx
+++ b/lune-interface/client/src/components/DiaryInput.jsx
@@ -60,7 +60,7 @@ const DiaryInput = ({ onSave, initialText = '', clearOnSave = false }) => {
         value={text}
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}
-        className="w-full min-h-[8rem] resize-none overflow-hidden rounded-2xl bg-white/8 hover:bg-white/10 backdrop-blur-lg p-4 md:p-6 text-lg leading-loose text-slate-100 placeholder:text-slate-400 outline-none ring-1 ring-inset ring-white/10 focus:ring-2 focus:ring-violet-300/60 transition shadow-[0_8px_40px_-16px_rgb(91_33_182/0.35)]"
+        className="frost w-full min-h-[8rem] resize-none overflow-hidden rounded-2xl p-4 md:p-6 text-lg leading-loose text-slate-200 placeholder:text-slate-400 outline-none ring-1 ring-inset focus:ring-2 focus:ring-violet-300/60 transition"
       />
       <div className="mt-8 flex items-center justify-between">
         <span className="text-xs text-slate-300">

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -74,7 +74,6 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
 
   return (
     <main className="relative">
-      <div className="absolute inset-0 bg-white/4 backdrop-blur-[6px] pointer-events-none rounded-[2rem]" />
       <div className="p-4 bg-gradient-to-br from-slate-900 via-zinc-900 to-slate-950 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
         <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center font-literata font-light">Lune Diary.</h1>
         <div className="flex gap-2 mb-4">

--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -74,7 +74,6 @@ export default function EntriesPage({ entries, folders, refreshEntries, refreshF
 
   return (
     <main className="relative">
-      <div className="absolute inset-0 bg-white/4 backdrop-blur-[6px] pointer-events-none rounded-[2rem]" />
       <div className="p-4 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-lunePurple text-3xl font-bold text-center font-literata font-light">Entries</h1>
@@ -114,7 +113,7 @@ export default function EntriesPage({ entries, folders, refreshEntries, refreshF
             key={entry.id}
             draggable // Make entries draggable
             onDragStart={(e) => handleDragStartEntry(e, entry.id)}
-            className="rounded-xl bg-white/6 p-4 shadow-md backdrop-blur-lg cursor-grab hover:shadow-[0_0_12px_#fcd34d80] hover:scale-[1.02] focus:scale-[1.02] transition-transform duration-500 ease-in-out"
+            className="frost rounded-xl p-4 shadow-md cursor-grab hover:shadow-[0_0_12px_#fcd34d80] hover:scale-[1.02] focus:scale-[1.02] transition-transform duration-500 ease-in-out"
             onClick={() => { startEdit(entry.id); navigate('/chat'); }}
           >
             <div className="text-xs text-slate-300 italic tracking-wide font-ibmPlexMono uppercase">{new Date(entry.timestamp).toLocaleString()}</div>

--- a/lune-interface/client/src/components/FolderViewPage.js
+++ b/lune-interface/client/src/components/FolderViewPage.js
@@ -63,7 +63,6 @@ export default function FolderViewPage({ allEntries, allFolders, startEdit, refr
 
   return (
     <main className="relative">
-      <div className="absolute inset-0 bg-white/4 backdrop-blur-[6px] pointer-events-none rounded-[2rem]" />
       <div className="p-4 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-lunePurple text-3xl font-bold font-literata font-light">
@@ -79,7 +78,7 @@ export default function FolderViewPage({ allEntries, allFolders, startEdit, refr
           entriesInFolder.map(entry => (
             <div
               key={entry.id}
-              className="rounded-xl bg-white/6 p-4 shadow-md backdrop-blur-lg cursor-pointer hover:shadow-[0_0_12px_#fcd34d80] hover:scale-[1.02] focus:scale-[1.02] transition-transform duration-500 ease-in-out"
+              className="frost rounded-xl p-4 shadow-md cursor-pointer hover:shadow-[0_0_12px_#fcd34d80] hover:scale-[1.02] focus:scale-[1.02] transition-transform duration-500 ease-in-out"
               onClick={() => { startEdit(entry.id); navigate('/chat'); }}
             >
               <div className="text-xs text-slate-300 italic tracking-wide font-ibmPlexMono uppercase">

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -160,6 +160,14 @@ body {
   scrollbar-width: none; /* Firefox */
 }
 
+/* Frost utility class */
+.frost {
+  @apply bg-white/5 backdrop-blur-lg ring-1 ring-white/10 shadow-[0_8px_40px_-16px_rgb(91_33_182/0.35)];
+}
+.frost:hover {
+  @apply bg-white/7;
+}
+
 @keyframes fadeIn {
   to {
     opacity: 1;


### PR DESCRIPTION
- Removed the full-page white overlay from main content areas.
- Introduced a `.frost` utility class for a consistent blurred glass effect.
- Applied `.frost` to:
    - DiaryInput textarea
    - Entry cards in EntriesPage and FolderViewPage
    - Footer button container in App.js
- Adjusted DiaryInput text color from slate-100 to slate-200 for better contrast against the new frost background.