### PR TITLE
Refactor: Remove local backgrounds to unify global gradient

### DIFF
--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -74,7 +74,7 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
 
   return (
     <main className="relative">
-      <div className="p-4 bg-gradient-to-br from-slate-900 via-zinc-900 to-slate-950 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
+      <div className="p-4 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out opacity-0 animate-fadeIn">
         <h1 className="text-lunePurple text-3xl font-bold mb-4 text-center font-literata font-light">Lune Diary.</h1>
         <div className="flex gap-2 mb-4">
         </div>


### PR DESCRIPTION
- Removed local background gradient from DockChat component to allow the global ::before pseudo-element's gradient to show through.
- Verified that other specified overlays and footer background classes were not present in the current codebase, requiring no direct changes for those specific items.