### PR TITLE
feat: Implement Loon Diary Entries Experience v0.2.1

### DIFF
--- a/lune-interface/client/src/components/DiaryFeed.css
+++ b/lune-interface/client/src/components/DiaryFeed.css
@@ -1,0 +1,26 @@
+.diary-feed-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); /* Responsive grid */
+  gap: 24px; /* Space between cards */
+  padding: 20px; /* Padding around the feed */
+  max-width: 680px; /* Max width as per spec */
+  margin: 0 auto; /* Center the feed if it's narrower than the viewport */
+}
+
+/* On smaller screens, go to a single column layout */
+@media (max-width: 679px) { /* 680px (max-width) - 1px */
+  .diary-feed-container {
+    /* When max-width is hit, grid-template-columns might only allow one column if 300px + gap > viewport.
+       However, to be explicit for very small screens: */
+    grid-template-columns: 1fr;
+    padding: 16px; /* Slightly less padding on mobile */
+    gap: 16px; /* Slightly less gap on mobile */
+  }
+}
+
+.diary-feed-empty {
+  color: var(--moon-mist);
+  text-align: center;
+  padding: 40px;
+  font-size: 1.1rem;
+}

--- a/lune-interface/client/src/components/DiaryFeed.jsx
+++ b/lune-interface/client/src/components/DiaryFeed.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import EntryCard from './ui/EntryCard';
+import './DiaryFeed.css';
+
+// Placeholder data - in a real app, this would come from state/props
+const placeholderEntries = [
+  {
+    id: 'e1',
+    title: 'First Day Musings',
+    snippet: 'The journey of a thousand miles begins with a single step. Today, I took that step into a new adventure...',
+    date: 'October 20, 2023',
+  },
+  {
+    id: 'e2',
+    title: 'A Walk in the Park',
+    snippet: 'The autumn leaves were vibrant, painting the park in hues of gold and crimson. A gentle breeze rustled through the trees.',
+    date: 'October 22, 2023',
+  },
+  {
+    id: 'e3',
+    title: 'Recipe for Success',
+    snippet: 'Found an amazing recipe for sourdough bread. The key is patience and a good starter. Can\'t wait to try it this weekend!',
+    date: 'October 24, 2023',
+  },
+  {
+    id: 'e4',
+    title: 'Stargazing Night',
+    snippet: 'The sky was incredibly clear tonight. Saw Mars and the Pleiades cluster. It felt like looking into infinity.',
+    date: 'October 25, 2023',
+  },
+];
+
+const DiaryFeed = ({ entries = placeholderEntries, onEntryClick, onEntryDelete }) => {
+  const handleEntryClick = (entryId) => {
+    if (onEntryClick) {
+      onEntryClick(entryId);
+    } else {
+      // Placeholder navigation for spec: "click routes to /entries/:id via 300ms slide-right"
+      // Actual routing and animation would depend on the app's routing/animation libraries.
+      console.log(`Navigating to /entries/${entryId}`);
+      // Simulate navigation delay for slide animation perception
+      setTimeout(() => {
+        window.location.href = `/entries/${entryId}`; // Simple redirect for now
+      }, 300);
+    }
+  };
+
+  const handleEntryDelete = (entryId) => {
+    // Placeholder for delete confirmation: "opens a confirm popover"
+    if (window.confirm('Are you sure you want to delete this entry?')) {
+      if (onEntryDelete) {
+        onEntryDelete(entryId);
+      } else {
+        console.log(`Deleting entry: ${entryId}`);
+        // In a real app, update state to remove the entry
+      }
+    }
+  };
+
+  if (!entries || entries.length === 0) {
+    return <p className="diary-feed-empty">No entries yet. Start writing!</p>;
+  }
+
+  return (
+    <div className="diary-feed-container" role="list" aria-label="Diary entries">
+      {entries.map(entry => (
+        <EntryCard
+          key={entry.id}
+          title={entry.title}
+          snippet={entry.snippet}
+          date={entry.date}
+          onClick={() => handleEntryClick(entry.id)}
+          onDelete={() => handleEntryDelete(entry.id)}
+          // EntryCard already has role="listitem"
+        />
+      ))}
+    </div>
+  );
+};
+
+export default DiaryFeed;

--- a/lune-interface/client/src/components/EntriesPage.css
+++ b/lune-interface/client/src/components/EntriesPage.css
@@ -1,0 +1,48 @@
+.entries-page-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh; /* Ensure it takes full viewport height */
+  transition: transform 300ms ease-in-out;
+  background-color: var(--ink-black); /* Or inherit from body, ensures content bg during slide */
+}
+
+.entries-page-wrapper.slide-out-active {
+  transform: translateX(-100%); /* Slide current content to the left */
+}
+
+.entries-page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 20px 16px 20px; /* Standard padding */
+  /* background-color: var(--ink-black); Optional: if not sticky or part of a larger sticky container */
+  /* z-index: 20; Ensure header is above FoldersRibbon if not sticky itself and ribbon is */
+}
+
+.entries-page-header h1 {
+  /* Typography for h1 is global (Playfair Display, --moon-mist) */
+  margin: 0; /* Remove default h1 margin */
+  font-size: 2.5rem; /* Example size, adjust as needed */
+}
+
+/* FoldersRibbon styles are in its own CSS file (sticky, etc.) */
+
+.entries-page-main-content {
+  flex-grow: 1; /* Allows main content to fill available space */
+  /* padding for DiaryFeed is handled within DiaryFeed.css (e.g. centering it) */
+}
+
+/* BackToChatButton styles are in its own CSS file (fixed position, etc.) */
+
+/* Reduced motion for slide animation */
+@media (prefers-reduced-motion: reduce) {
+  .entries-page-wrapper {
+    transition: none; /* No transition for page slide */
+  }
+  .entries-page-wrapper.slide-out-active {
+    transform: none; /* No actual slide */
+    /* Consider a very quick fade if any feedback is desired, or simply navigate immediately */
+    /* opacity: 0; */
+    /* transition: opacity 50ms ease-out; */
+  }
+}

--- a/lune-interface/client/src/components/EntriesPage.jsx
+++ b/lune-interface/client/src/components/EntriesPage.jsx
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from 'react';
+import PrimaryButton from './ui/PrimaryButton';
+import BackToChatButton from './ui/BackToChatButton';
+import FoldersRibbon from './FoldersRibbon';
+import DiaryFeed from './DiaryFeed';
+import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts'; // Adjusted path
+import './EntriesPage.css'; // For page-specific styles like slide animation
+
+// Assuming App.js passes these props, or they are fetched here
+const EntriesPage = ({ entries, folders, refreshEntries, refreshFolders, startEdit, setFolders }) => {
+  const [isSlidingOut, setIsSlidingOut] = useState(false);
+
+  // Initialize keyboard shortcuts
+  useKeyboardShortcuts({
+    n: 'add-folder-button', // ID for the "Add Folder +" button
+    b: 'back-to-chat-button', // ID for the "Back to Chat" button
+  });
+
+  const handleAddFolder = () => {
+    // Placeholder: In a real app, this would likely open a modal or inline form
+    const newFolderName = prompt('Enter new folder name:');
+    if (newFolderName) {
+      // Simulate adding a folder and refreshing
+      // This logic would ideally involve an API call and then refreshing folders state
+      const newFolder = {
+        id: `temp-${Date.now()}`,
+        name: newFolderName,
+        count: 0
+      };
+      if (setFolders) { // Check if setFolders prop is passed from App.js
+         setFolders(prev => [...(prev || []), newFolder]);
+      } else {
+        // Fallback if setFolders is not available (e.g. if FoldersRibbon manages its own state fully)
+        console.log('Folder added (simulated):', newFolder);
+      }
+      // if (refreshFolders) refreshFolders();
+    }
+  };
+
+  const handleEntryCardClick = (entryId) => {
+    console.log(`Entry card ${entryId} clicked, preparing to slide out.`);
+    setIsSlidingOut(true);
+    // Actual navigation and view change would happen after the animation.
+    // The 300ms slide is a visual effect before routing.
+    setTimeout(() => {
+      // In a real app, you'd use your router here.
+      // For example, history.push(`/entries/${entryId}`);
+      alert(`Navigating to entry ${entryId}... (after slide)`);
+      // Reset slide state if user navigates back or for next interaction
+      // This might be handled differently depending on routing setup.
+      // For now, this just simulates the visual part.
+      // setIsSlidingOut(false); // This would be reset when the new page/view loads
+
+      // For now, just use window.location.href as in DiaryFeed, but without the internal timeout
+      window.location.href = `/entries/${entryId}`;
+    }, 300); // Corresponds to slide animation duration
+  };
+
+  const handleBackToChat = () => {
+    // Navigate to chat page, potentially with a slide-left animation if desired
+    alert('Navigating back to chat...');
+    window.location.href = '/chat'; // Example navigation
+  };
+
+
+  // Dummy data if not provided by props (for standalone testing or if App.js doesn't pass them yet)
+  const currentEntries = entries || [
+    { id: 'e1', title: 'My First Entry', snippet: 'Details here...', date: 'Today' },
+    { id: 'e2', title: 'Another Day', snippet: 'More details...', date: 'Yesterday' },
+  ];
+  const currentFolders = folders || [
+    { id: 'f1', name: 'All', count: 2 },
+    { id: 'f2', name: 'Work', count: 1 },
+  ];
+
+
+  return (
+    <div className={`entries-page-wrapper ${isSlidingOut ? 'slide-out-active' : ''}`}>
+      <header className="entries-page-header">
+        <h1>Entries</h1>
+        <PrimaryButton id="add-folder-button" onClick={handleAddFolder}>
+          Add Folder +
+        </PrimaryButton>
+      </header>
+
+      <FoldersRibbon
+        // folders={currentFolders} // FoldersRibbon uses its own placeholder data for now
+        onSelectFolder={(folderId) => console.log(`Folder ${folderId} selected in page`)}
+        // onRenameFolder, onDeleteFolder can be wired up here if needed
+      />
+
+      <main className="entries-page-main-content">
+        <DiaryFeed
+          entries={currentEntries}
+          onEntryClick={handleEntryCardClick} // Use the page-level handler for slide effect
+          // onEntryDelete is handled by EntryCard directly via keyboard,
+          // but DiaryFeed also has a handler if needed for other triggers.
+        />
+      </main>
+
+      <BackToChatButton id="back-to-chat-button" onClick={handleBackToChat} />
+    </div>
+  );
+};
+
+export default EntriesPage;

--- a/lune-interface/client/src/components/EntriesPage.test.js
+++ b/lune-interface/client/src/components/EntriesPage.test.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import EntriesPage from './EntriesPage';
+
+// Mock child components and hooks to isolate EntriesPage logic if needed,
+// or allow them to render if their interactions are part of what's being tested.
+// For now, let's allow them to render with their placeholder states.
+
+jest.mock('./ui/PrimaryButton.css', () => ({}));
+jest.mock('./ui/BackToChatButton.css', () => ({}));
+jest.mock('./ui/FolderChip.css', () => ({}));
+jest.mock('./ui/EntryCard.css', () => ({}));
+jest.mock('./FoldersRibbon.css', () => ({}));
+jest.mock('./DiaryFeed.css', () => ({}));
+jest.mock('./EntriesPage.css', () => ({}));
+jest.mock('../hooks/useKeyboardShortcuts', () => jest.fn()); // Mock the hook itself
+jest.mock('../styles/motion.css', () => ({}));
+
+
+expect.extend(toHaveNoViolations);
+
+describe('EntriesPage', () => {
+  const mockEntries = [
+    { id: 'e1', title: 'Entry 1', snippet: 'Snippet 1', date: 'Date 1' },
+  ];
+  const mockFolders = [
+    { id: 'f1', name: 'Folder 1', count: 1 },
+  ];
+
+  const mockUseKeyboardShortcuts = require('../hooks/useKeyboardShortcuts');
+
+  beforeEach(() => {
+    mockUseKeyboardShortcuts.mockClear();
+     // Mock window.confirm for tests that might trigger it (e.g., folder/entry delete)
+    global.confirm = jest.fn(() => true);
+    // Mock window.prompt
+    global.prompt = jest.fn(() => 'New Name');
+     // Mock window.alert
+    global.alert = jest.fn();
+    // Mock window.location.href
+    Object.defineProperty(window, 'location', {
+        value: { href: '' },
+        writable: true,
+    });
+  });
+
+  test('renders header, folders ribbon, diary feed, and back button, and has no a11y violations', async () => {
+    const { container } = render(
+      <EntriesPage entries={mockEntries} folders={mockFolders} />
+    );
+
+    // Check for header elements
+    expect(screen.getByRole('heading', { name: /Entries/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add Folder \+/i })).toBeInTheDocument(); // This is the add-folder-button
+
+    // Check for FoldersRibbon (presence of its role or a chip)
+    expect(screen.getByRole('tablist', { name: /Folder categories/i })).toBeInTheDocument();
+    expect(screen.getByText(mockFolders[0].name)).toBeInTheDocument();
+
+
+    // Check for DiaryFeed (presence of its role or an entry)
+    expect(screen.getByRole('list', { name: /Diary entries/i })).toBeInTheDocument();
+    expect(screen.getByText(mockEntries[0].title)).toBeInTheDocument();
+
+    // Check for BackToChatButton
+    expect(screen.getByRole('button', { name: /Back to Chat/i })).toBeInTheDocument(); // This is the back-to-chat-button
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('initializes useKeyboardShortcuts with correct target IDs', () => {
+    render(<EntriesPage entries={mockEntries} folders={mockFolders} />);
+    expect(mockUseKeyboardShortcuts).toHaveBeenCalledWith({
+      n: 'add-folder-button',
+      b: 'back-to-chat-button',
+    });
+  });
+
+  test('handles "Add Folder" button click', () => {
+    render(<EntriesPage entries={mockEntries} folders={mockFolders} setFolders={jest.fn()} />);
+    const addFolderButton = screen.getByRole('button', { name: /Add Folder \+/i });
+    fireEvent.click(addFolderButton);
+    expect(global.prompt).toHaveBeenCalledWith('Enter new folder name:');
+    // Further tests could assert setFolders was called if prompt returns a value
+  });
+
+  test('handles entry card click and page slide animation', async () => {
+    const { container } = render(<EntriesPage entries={mockEntries} folders={mockFolders} />);
+    const entryCard = screen.getByText(mockEntries[0].title).closest('.entry-card'); // EntryCard has this class
+
+    expect(entryCard).toBeInTheDocument();
+
+    const pageWrapper = container.firstChild; // Assuming .entries-page-wrapper is the first child
+    expect(pageWrapper).not.toHaveClass('slide-out-active');
+
+    fireEvent.click(entryCard);
+
+    expect(pageWrapper).toHaveClass('slide-out-active');
+
+    // Fast-forward timers for the setTimeout in handleEntryCardClick
+    await act(async () => {
+      jest.advanceTimersByTime(300);
+    });
+    // Check if navigation was attempted (mocked to alert)
+    expect(window.location.href).toBe(`/entries/${mockEntries[0].id}`);
+  });
+
+  test('handles "Back to Chat" button click', () => {
+    render(<EntriesPage entries={mockEntries} folders={mockFolders} />);
+    const backToChatButton = screen.getByRole('button', { name: /Back to Chat/i });
+    fireEvent.click(backToChatButton);
+    expect(global.alert).toHaveBeenCalledWith('Navigating back to chat...');
+    expect(window.location.href).toBe('/chat');
+  });
+
+  // Note: Testing the actual effect of useKeyboardShortcuts (i.e., 'n' and 'b' key presses)
+  // would require not mocking the hook and ensuring the buttons are rendered with the correct IDs.
+  // The current test 'initializes useKeyboardShortcuts' verifies it's called correctly.
+  // To test the full interaction:
+  // 1. Don't mock useKeyboardShortcuts.
+  // 2. Ensure EntriesPage renders PrimaryButton with id="add-folder-button" and BackToChatButton with id="back-to-chat-button".
+  // 3. Dispatch keydown events for 'n' and 'b' on the document.
+  // 4. Assert that the respective button click handlers (or mocked button.click()) were called.
+  // This is more of an integration test for the hook and page.
+});

--- a/lune-interface/client/src/components/FoldersRibbon.css
+++ b/lune-interface/client/src/components/FoldersRibbon.css
@@ -1,0 +1,37 @@
+.folders-ribbon-container {
+  position: sticky;
+  top: 0;
+  background-color: rgba(var(--ink-black-rgb), 0.8); /* Semi-transparent background to see content scroll under */
+  backdrop-filter: blur(10px); /* Frosted glass effect for modern UIs */
+  -webkit-backdrop-filter: blur(10px);
+  padding: 16px 20px; /* Adjust padding as needed */
+  display: flex;
+  gap: 16px; /* Space between folder chips */
+  overflow-x: auto;
+  z-index: 10; /* Ensure it stays on top of other content */
+
+  /* Hide scrollbar for a cleaner look, but still scrollable */
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;  /* IE and Edge */
+}
+
+.folders-ribbon-container::-webkit-scrollbar {
+  display: none; /* Safari and Chrome */
+}
+
+/* Styling for individual chips is in FolderChip.css */
+/* This container just manages their layout and scroll behavior. */
+
+/* Responsive: below 480px, convert to swipeable carousel */
+@media (max-width: 480px) {
+  .folders-ribbon-container {
+    scroll-snap-type: x mandatory;
+    /* Add some padding so snapped items don't stick to the very edge */
+    scroll-padding: 0 20px;
+  }
+
+  .folders-ribbon-container > * { /* Target FolderChip components */
+    scroll-snap-align: start; /* Snap to the start of each chip */
+    flex-shrink: 0; /* Prevent chips from shrinking to fit */
+  }
+}

--- a/lune-interface/client/src/components/FoldersRibbon.jsx
+++ b/lune-interface/client/src/components/FoldersRibbon.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import FolderChip from './ui/FolderChip';
+import './FoldersRibbon.css';
+
+// Placeholder data - in a real app, this would come from state/props
+const initialFolders = [
+  { id: '1', name: 'All Notes', count: 125 },
+  { id: '2', name: 'Work', count: 30 },
+  { id: '3', name: 'Personal', count: 45 },
+  { id: '4', name: 'Ideas', count: 50 },
+  { id: '5', name: 'Travel', count: 15 },
+  { id: '6', name: 'Recipes', count: 22 },
+  { id: '7', name: 'Archive', count: 800 },
+  { id: '8', name: 'To Read', count: 10 },
+];
+
+const FoldersRibbon = ({ onSelectFolder, onRenameFolder, onDeleteFolder }) => {
+  const [folders, setFolders] = useState(initialFolders); // Manage folder state locally for now
+  const [selectedFolderId, setSelectedFolderId] = useState(initialFolders[0]?.id || null);
+
+  const handleChipClick = (folderId) => {
+    setSelectedFolderId(folderId);
+    if (onSelectFolder) {
+      onSelectFolder(folderId);
+    }
+    console.log(`Selected folder: ${folderId}`);
+  };
+
+  const handleChipDoubleClick = (folder) => {
+    const newName = prompt(`Rename folder "${folder.name}":`, folder.name);
+    if (newName && newName !== folder.name) {
+      setFolders(prevFolders => prevFolders.map(f => f.id === folder.id ? { ...f, name: newName } : f));
+      if (onRenameFolder) {
+        onRenameFolder(folder.id, newName);
+      }
+      console.log(`Rename folder ${folder.id} to "${newName}"`);
+    }
+  };
+
+  const handleChipLongPress = (folder) => {
+    if (window.confirm(`Are you sure you want to delete folder "${folder.name}"?`)) {
+      setFolders(prevFolders => prevFolders.filter(f => f.id !== folder.id));
+      if (onDeleteFolder) {
+        onDeleteFolder(folder.id);
+      }
+      console.log(`Delete folder ${folder.id}`);
+      // If the selected folder is deleted, select the first one if available
+      if (selectedFolderId === folder.id) {
+        setSelectedFolderId(folders[0]?.id || null);
+         if (onSelectFolder && folders[0]) {
+            onSelectFolder(folders[0].id);
+        }
+      }
+    }
+  };
+
+  return (
+    <div className="folders-ribbon-container" role="tablist" aria-label="Folder categories">
+      {folders.map(folder => (
+        <FolderChip
+          key={folder.id}
+          name={folder.name}
+          count={folder.count}
+          onClick={() => handleChipClick(folder.id)}
+          onDoubleClick={() => handleChipDoubleClick(folder)}
+          onLongPress={() => handleChipLongPress(folder)}
+          // ARIA attributes for tab role
+          aria-selected={selectedFolderId === folder.id}
+          // id={`folder-tab-${folder.id}`} // Optional: for aria-controls if needed
+          // aria-controls={`folder-panel-${folder.id}`} // Optional
+        />
+      ))}
+    </div>
+  );
+};
+
+export default FoldersRibbon;

--- a/lune-interface/client/src/components/ui/BackToChatButton.css
+++ b/lune-interface/client/src/components/ui/BackToChatButton.css
@@ -1,0 +1,55 @@
+.back-to-chat-button {
+  position: fixed;
+  bottom: 24px;
+  left: 24px;
+  background-color: transparent;
+  border: 2px solid var(--violet-deep);
+  color: var(--violet-deep); /* Icon and text color */
+  padding: 8px 16px;
+  border-radius: 9999px; /* Pill shape */
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 0.9rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  z-index: 100; /* Ensure it's above most content */
+
+  opacity: 0;
+  transform: translateY(20px); /* Start slightly lower for fade-in effect */
+  transition: opacity 400ms ease-out, transform 400ms ease-out;
+  pointer-events: none; /* Not interactive when hidden */
+}
+
+.back-to-chat-button.visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto; /* Interactive when visible */
+}
+
+.back-to-chat-button:hover,
+.back-to-chat-button:focus-visible {
+  background-color: rgba(var(--violet-deep-rgb), 0.1); /* Subtle hover fill */
+  border-color: var(--violet-deep); /* Ensure border stays */
+  color: var(--violet-deep);
+  outline: none;
+}
+
+.back-to-chat-icon {
+  font-size: 1.2em; /* Make icon slightly larger than text */
+  line-height: 1; /* Prevent extra spacing */
+}
+
+/* Text part can be hidden on very small screens if needed, or icon only */
+/* .back-to-chat-text { ... } */
+
+/* Reduced motion: just fade, no transform */
+@media (prefers-reduced-motion: reduce) {
+  .back-to-chat-button {
+    transform: translateY(0); /* No translate, just fade */
+  }
+  .back-to-chat-button.visible {
+    transform: translateY(0);
+  }
+}

--- a/lune-interface/client/src/components/ui/BackToChatButton.jsx
+++ b/lune-interface/client/src/components/ui/BackToChatButton.jsx
@@ -1,0 +1,69 @@
+import React, { useState, useEffect, useRef } from 'react';
+import './BackToChatButton.css';
+
+const BackToChatButton = ({ onClick }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const buttonRef = useRef(null);
+
+  useEffect(() => {
+    let observer;
+    let timeoutId;
+
+    const handleScroll = () => {
+      // Show button after 1s of scrolling from top
+      // This simple check works if page is scrollable from the start.
+      // A more robust way for "1s scroll" might involve tracking scroll start time.
+      // For now, show after scrolling down a bit (e.g., 100px) and then apply delay.
+
+      // Clear any existing timeout to avoid multiple fade-ins if user scrolls up/down quickly
+      clearTimeout(timeoutId);
+
+      if (window.scrollY > 100) { // User has scrolled down a bit
+        timeoutId = setTimeout(() => {
+          setIsVisible(true);
+        }, 700); // Spec says "fade-in after 1s scroll", animation is 400ms.
+                     // Total: 700ms delay + 400ms fade = ~1.1s effect.
+                     // Let's make it 600ms delay for 1s total.
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    // More robust: IntersectionObserver to detect when a certain point is passed.
+    // However, the spec says "1s scroll", implying time-based after scroll starts.
+    // The current implementation is a simplified version: show 600ms after scrolling past 100px.
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll(); // Initial check in case page loads scrolled
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      clearTimeout(timeoutId);
+      if (observer) observer.disconnect();
+    };
+  }, []);
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    } else {
+      // Placeholder action
+      alert('Back to Chat clicked!');
+      // window.location.href = '/chat'; // Example navigation
+    }
+  };
+
+  return (
+    <button
+      ref={buttonRef}
+      className={`back-to-chat-button ${isVisible ? 'visible' : ''}`}
+      onClick={handleClick}
+      aria-label="Back to Chat"
+    >
+      <span className="back-to-chat-icon" aria-hidden="true">↩</span>
+      <span className="back-to-chat-text">Back to Chat</span>
+    </button>
+  );
+};
+
+export default BackToChatButton;

--- a/lune-interface/client/src/components/ui/BackToChatButton.test.js
+++ b/lune-interface/client/src/components/ui/BackToChatButton.test.js
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import BackToChatButton from './BackToChatButton';
+
+// Mock CSS import
+jest.mock('./BackToChatButton.css', () => ({}));
+expect.extend(toHaveNoViolations);
+
+describe('BackToChatButton', () => {
+  // Helper to simulate scroll event
+  const simulateScroll = (scrollY) => {
+    global.window.scrollY = scrollY;
+    fireEvent.scroll(global.window);
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    global.window.scrollY = 0; // Reset scroll position
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('renders button with correct text and icon, and has no a11y violations initially hidden', async () => {
+    const { container } = render(<BackToChatButton />);
+    const button = screen.getByRole('button', { name: /Back to Chat/i });
+    expect(button).toBeInTheDocument();
+    expect(screen.getByText('↩')).toBeInTheDocument(); // Icon
+    expect(button).not.toHaveClass('visible'); // Initially hidden or starts transition from hidden
+
+    const results = await axe(container);
+    // jest-axe might report issues on initially hidden interactive elements if not handled carefully.
+    // We expect it to be not visible to pointer events initially.
+    // Depending on CSS, it might be fine. Let's check.
+    expect(results).toHaveNoViolations();
+  });
+
+  test('becomes visible after scrolling and delay', () => {
+    render(<BackToChatButton />);
+    const button = screen.getByRole('button', { name: /Back to Chat/i });
+
+    expect(button).not.toHaveClass('visible');
+
+    act(() => {
+      simulateScroll(200); // Scroll down
+    });
+    // Wait for the timeout inside the component (e.g., 600ms)
+    act(() => {
+      jest.advanceTimersByTime(599);
+    });
+    expect(button).not.toHaveClass('visible'); // Still not visible
+
+    act(() => {
+      jest.advanceTimersByTime(1); // Cross the 600ms threshold
+    });
+    expect(button).toHaveClass('visible');
+  });
+
+  test('calls onClick handler when clicked', () => {
+    const handleClick = jest.fn();
+    render(<BackToChatButton onClick={handleClick} />);
+    const button = screen.getByRole('button', { name: /Back to Chat/i });
+
+    // Make it visible for the click test
+    act(() => {
+      simulateScroll(200);
+      jest.advanceTimersByTime(600);
+    });
+    expect(button).toHaveClass('visible');
+
+    fireEvent.click(button);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('hides again when scrolled to top', () => {
+    render(<BackToChatButton />);
+    const button = screen.getByRole('button', { name: /Back to Chat/i });
+
+    // Make it visible
+    act(() => {
+      simulateScroll(200);
+      jest.advanceTimersByTime(600);
+    });
+    expect(button).toHaveClass('visible');
+
+    // Scroll back to top
+    act(() => {
+      simulateScroll(0);
+      // Visibility change should be immediate if scrollY < 100, timeout is cleared
+      // jest.advanceTimersByTime(100); // Ensure any potential debounce/throttle has passed
+    });
+     expect(button).not.toHaveClass('visible');
+  });
+});

--- a/lune-interface/client/src/components/ui/EntryCard.css
+++ b/lune-interface/client/src/components/ui/EntryCard.css
@@ -1,0 +1,109 @@
+.entry-card {
+  position: relative; /* For positioning the loop dot and trash icon */
+  background-color: #111116;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: inset 0 0 0 4px rgba(var(--moon-mist-rgb), 0.08);
+  color: var(--moon-mist);
+  font-family: 'Inter', sans-serif;
+  cursor: pointer;
+  transition: background-color 0.3s ease-out, box-shadow 0.3s ease-out;
+  overflow: hidden; /* Ensures child elements like loop-dot don't break border-radius */
+}
+
+.entry-card:hover,
+.entry-card:focus-visible {
+  background-color: rgba(var(--violet-deep-rgb), 0.2);
+  box-shadow: inset 0 0 0 4px rgba(var(--moon-mist-rgb), 0.08), /* Keep original inset outline */
+              0 4px 12px rgba(var(--violet-deep-rgb), 0.35);
+  outline: none; /* Remove default focus outline if custom is sufficient */
+}
+
+.entry-card-loop-dot {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 8px;
+  height: 8px;
+  background-color: var(--aqua-loop);
+  border-radius: 50%;
+  animation: pulse-loop-dot 1000ms cubic-bezier(0.4, 0, 0.6, 1) 300ms 1; /* 300ms delay, 1 iteration */
+}
+
+.entry-card-content {
+  /* Normal content flow */
+}
+
+.entry-card-title {
+  font-family: 'Playfair Display', serif; /* As per spec for h1-h3 */
+  font-weight: 600;
+  font-size: 1.25rem; /* Example size */
+  color: var(--moon-mist);
+  margin-top: 0; /* Reset margin if h3 has default */
+  margin-bottom: 8px;
+}
+
+.entry-card-snippet {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: rgba(var(--moon-mist-rgb), 0.8); /* Slightly muted snippet */
+  margin-bottom: 8px;
+  /* For multi-line ellipsis: */
+  display: -webkit-box;
+  -webkit-line-clamp: 3; /* Show 3 lines */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-height: calc(0.9rem * 1.5 * 3); /* Fallback for max height */
+}
+
+.entry-card-date {
+  font-size: 0.8rem;
+  color: rgba(var(--moon-mist-rgb), 0.6); /* More muted date */
+}
+
+.entry-card-delete-icon {
+  position: absolute;
+  top: 12px; /* Adjust for visual preference */
+  right: 12px; /* Adjust for visual preference */
+  background-color: var(--brazen-gold);
+  color: var(--ink-black); /* For contrast on brazen-gold */
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px; /* Adjust icon size */
+  cursor: pointer;
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+  opacity: 1; /* Opacity is handled by JS for reveal, but good to have a base */
+  /* The spec says opacity 0->1 on hover-reveal, which is handled by isHovered in component */
+}
+
+.entry-card-delete-icon:hover {
+  transform: scale(1.1);
+}
+
+/* Reduced motion considerations for animations and transitions will be in motion.css */
+
+@media (prefers-reduced-motion: reduce) {
+  .entry-card {
+    /* Keep background-color transition as it's subtle, or disable if preferred */
+    /* transition: background-color 0.3s ease-out; */
+  }
+  .entry-card:hover,
+  .entry-card:focus-visible {
+    /* Disable hover shadow if it's too much, or use a static one. */
+    /* Keep the inset shadow, remove the outer glow */
+    box-shadow: inset 0 0 0 4px rgba(var(--moon-mist-rgb), 0.08);
+  }
+
+  .entry-card-loop-dot {
+    animation: none; /* Disable pulse animation */
+  }
+
+  .entry-card-delete-icon:hover {
+    transform: none; /* Disable scaling on delete icon */
+  }
+}

--- a/lune-interface/client/src/components/ui/EntryCard.jsx
+++ b/lune-interface/client/src/components/ui/EntryCard.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import './EntryCard.css';
+// Assuming an icon component or SVG for trash icon
+// For now, using a simple text character or placeholder.
+// import { FaTrash } from 'react-icons/fa'; // Example if using react-icons
+
+const EntryCard = ({ title, snippet, date, onClick, onDelete }) => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  // Placeholder for trash icon - to be replaced with actual SVG or icon component
+  const TrashIcon = () => (
+    <span
+      role="button"
+      aria-label="Delete entry"
+      className="entry-card-delete-icon"
+      onClick={(e) => {
+        e.stopPropagation(); // Prevent card click when deleting
+        if (onDelete) onDelete();
+      }}
+    >
+      🗑️
+    </span>
+  );
+
+  return (
+    <div
+      className="entry-card"
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      role="listitem" // As part of a diary feed (list)
+      tabIndex={0} // Make it focusable
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          if (onClick) {
+            e.preventDefault();
+            onClick();
+          }
+        } else if (e.key === 'Delete' || e.key === 'Backspace') {
+          if (onDelete) {
+            e.preventDefault();
+            // To maintain consistency with hover-reveal,
+            // we might want to briefly show the icon or just call delete.
+            // For now, directly call onDelete.
+            onDelete();
+          }
+        }
+      }}
+    >
+      <div className="entry-card-loop-dot"></div>
+      <div className="entry-card-content">
+        <h3 className="entry-card-title">{title}</h3>
+        <p className="entry-card-snippet">{snippet}</p>
+        <p className="entry-card-date">{date}</p>
+      </div>
+      {isHovered && onDelete && <TrashIcon />}
+    </div>
+  );
+};
+
+export default EntryCard;

--- a/lune-interface/client/src/components/ui/EntryCard.stories.js
+++ b/lune-interface/client/src/components/ui/EntryCard.stories.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import EntryCard from './EntryCard';
+// Import motion.css to ensure animations are applied in Storybook
+import '../../styles/motion.css';
+
+export default {
+  title: 'Components/UI/EntryCard',
+  component: EntryCard,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text', description: 'Title of the diary entry' },
+    snippet: { control: 'text', description: 'A short snippet of the entry content' },
+    date: { control: 'text', description: 'Date of the entry' },
+    onClick: { action: 'clicked', description: 'Handler for card click' },
+    onDelete: { action: 'deleted', description: 'Handler for delete icon click' },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: '340px', margin: '20px' }}> {/* Max-width similar to a column in the feed */}
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Default = {
+  args: {
+    title: 'A Wonderful Day',
+    snippet: 'Today was filled with joy and sunshine. We went to the park and had a lovely picnic. The birds were singing and the flowers were in full bloom.',
+    date: 'October 26, 2023',
+    onDelete: () => alert('Delete triggered!'), // Provide a dummy handler for story
+  },
+};
+
+export const ShortContent = {
+  args: {
+    title: 'Quick Note',
+    snippet: 'Remember to buy milk.',
+    date: 'October 27, 2023',
+    onDelete: () => alert('Delete triggered!'),
+  },
+};
+
+export const LongTitleAndSnippet = {
+  args: {
+    title: 'Reflections on the Ephemeral Nature of Time and the Universe',
+    snippet: 'It is a curious thing, time. It marches ever onward, unyielding, yet our perception of it shifts like desert sands. Sometimes moments stretch into eternities, and other times years slip by in what feels like a fleeting breath. This contemplation leads one to ponder the vastness of the cosmos and our small, yet significant, place within it all.',
+    date: 'November 15, 2023',
+    onDelete: () => alert('Delete triggered!'),
+  },
+};
+
+export const NoDeleteAction = {
+  args: {
+    title: 'Read Only Entry',
+    snippet: 'This entry cannot be deleted from the UI here.',
+    date: 'October 28, 2023',
+    // onDelete is not provided
+  },
+};
+
+export const MinimalContent = {
+  args: {
+    title: '...',
+    snippet: '...',
+    date: 'Jan 1, 2024',
+    onDelete: () => alert('Delete triggered!'),
+  },
+};

--- a/lune-interface/client/src/components/ui/EntryCard.test.js
+++ b/lune-interface/client/src/components/ui/EntryCard.test.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import EntryCard from './EntryCard';
+
+// Mock CSS imports
+jest.mock('./EntryCard.css', () => ({}));
+jest.mock('../../styles/motion.css', () => ({}));
+expect.extend(toHaveNoViolations);
+
+describe('EntryCard', () => {
+  const defaultProps = {
+    title: 'Test Title',
+    snippet: 'Test snippet of content.',
+    date: 'Jan 1, 2024',
+    onClick: jest.fn(),
+    onDelete: jest.fn(),
+  };
+
+  beforeEach(() => {
+    defaultProps.onClick.mockClear();
+    defaultProps.onDelete.mockClear();
+  });
+
+  test('renders title, snippet, and date, and has no a11y violations', async () => {
+    const { container } = render(<EntryCard {...defaultProps} />);
+    expect(screen.getByText(defaultProps.title)).toBeInTheDocument();
+    expect(screen.getByText(defaultProps.snippet)).toBeInTheDocument();
+    expect(screen.getByText(defaultProps.date)).toBeInTheDocument();
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('has role="listitem" and is focusable', () => {
+    render(<EntryCard {...defaultProps} />);
+    const cardElement = screen.getByRole('listitem');
+    expect(cardElement).toBeInTheDocument();
+    cardElement.focus();
+    expect(cardElement).toHaveFocus();
+  });
+
+  test('calls onClick handler when card is clicked', () => {
+    render(<EntryCard {...defaultProps} />);
+    fireEvent.click(screen.getByRole('listitem'));
+    expect(defaultProps.onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onClick handler when Enter key is pressed on a focused card', () => {
+    render(<EntryCard {...defaultProps} />);
+    const cardElement = screen.getByRole('listitem');
+    cardElement.focus();
+    fireEvent.keyDown(cardElement, { key: 'Enter', code: 'Enter' });
+    expect(defaultProps.onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onClick handler when Space key is pressed on a focused card', () => {
+    render(<EntryCard {...defaultProps} />);
+    const cardElement = screen.getByRole('listitem');
+    cardElement.focus();
+    fireEvent.keyDown(cardElement, { key: ' ', code: 'Space' });
+    expect(defaultProps.onClick).toHaveBeenCalledTimes(1);
+  });
+
+  describe('Delete Icon', () => {
+    test('is not visible by default if onDelete is provided', () => {
+      render(<EntryCard {...defaultProps} />);
+      // The icon is conditionally rendered based on isHovered state, so it won't be in the DOM initially.
+      expect(screen.queryByRole('button', { name: /Delete entry/i })).not.toBeInTheDocument();
+    });
+
+    test('becomes visible on mouseEnter and calls onDelete when clicked', () => {
+      render(<EntryCard {...defaultProps} />);
+      const cardElement = screen.getByRole('listitem');
+
+      fireEvent.mouseEnter(cardElement);
+      const deleteButton = screen.getByRole('button', { name: /Delete entry/i });
+      expect(deleteButton).toBeInTheDocument();
+
+      fireEvent.click(deleteButton);
+      expect(defaultProps.onDelete).toHaveBeenCalledTimes(1);
+      // Ensure card's onClick was not called due to event propagation
+      expect(defaultProps.onClick).not.toHaveBeenCalled();
+    });
+
+    test('is hidden on mouseLeave', () => {
+      render(<EntryCard {...defaultProps} />);
+      const cardElement = screen.getByRole('listitem');
+
+      fireEvent.mouseEnter(cardElement);
+      expect(screen.getByRole('button', { name: /Delete entry/i })).toBeInTheDocument();
+
+      fireEvent.mouseLeave(cardElement);
+      expect(screen.queryByRole('button', { name: /Delete entry/i })).not.toBeInTheDocument();
+    });
+
+    test('is not rendered if onDelete prop is not provided', () => {
+      const propsWithoutDelete = { ...defaultProps, onDelete: undefined };
+      render(<EntryCard {...propsWithoutDelete} />);
+      const cardElement = screen.getByRole('listitem');
+
+      fireEvent.mouseEnter(cardElement);
+      expect(screen.queryByRole('button', { name: /Delete entry/i })).not.toBeInTheDocument();
+    });
+  });
+
+  test('loop dot is present', () => {
+    render(<EntryCard {...defaultProps} />);
+    // The loop dot is a div with a specific class, not interactive itself.
+    // We can check for its presence if it has a unique identifier or test its container.
+    // For now, assuming its presence if the card renders. A more specific test might involve
+    // checking its computed style for the animation if that were easily testable in JSDOM,
+    // or giving it a data-testid.
+    // Simple check:
+    const cardElement = screen.getByRole('listitem');
+    expect(cardElement.querySelector('.entry-card-loop-dot')).toBeInTheDocument();
+  });
+});

--- a/lune-interface/client/src/components/ui/FolderChip.css
+++ b/lune-interface/client/src/components/ui/FolderChip.css
@@ -1,0 +1,67 @@
+.folder-chip {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%; /* Makes it a circle */
+  border: 2px solid var(--violet-deep);
+  background-color: transparent; /* Or a very subtle background if needed */
+  color: var(--moon-mist); /* Default text color */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 8px; /* Adjust padding as needed for text */
+  box-sizing: border-box;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  text-align: center;
+  transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), box-shadow 0.2s ease-out;
+  /* For prefers-reduced-motion, this transition will be overridden if transform is disabled */
+}
+
+.folder-chip:hover,
+.folder-chip:focus-visible {
+  transform: translateY(-4px);
+  /* Optional: add a subtle shadow or glow for better feedback */
+  box-shadow: 0 2px 8px rgba(var(--violet-deep-rgb, 91, 46, 255), 0.3); /* Use RGB version of violet-deep if available or define one */
+}
+
+.folder-chip:active {
+  transform: translateY(-2px) scale(0.98); /* Click feedback */
+}
+
+.folder-chip-name {
+  font-size: 0.8rem; /* Adjust as needed */
+  font-weight: 600;
+  line-height: 1.2;
+  display: -webkit-box; /* For multi-line ellipsis */
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-height: calc(0.8rem * 1.2 * 2); /* Max 2 lines */
+}
+
+.folder-chip-count {
+  font-size: 0.7rem; /* Adjust as needed */
+  opacity: 0.8;
+  margin-top: 2px;
+}
+
+/*
+  The --violet-deep-rgb variable is now defined globally in tokens.css
+  for use in box-shadow rgba().
+*/
+
+@media (prefers-reduced-motion: reduce) {
+  .folder-chip {
+    transition: box-shadow 0.2s ease-out; /* Only transition shadow if it's kept */
+  }
+  .folder-chip:hover,
+  .folder-chip:focus-visible {
+    transform: none; /* Disable translation */
+    box-shadow: none; /* Optionally disable shadow/glow or use a static one */
+  }
+  .folder-chip:active {
+    transform: none; /* Disable click feedback scaling/translation */
+  }
+}

--- a/lune-interface/client/src/components/ui/FolderChip.jsx
+++ b/lune-interface/client/src/components/ui/FolderChip.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import './FolderChip.css';
+
+const FolderChip = ({ name, count, onClick, onDoubleClick, onLongPress }) => {
+  let longPressTimer;
+
+  const handleMouseDown = () => {
+    longPressTimer = setTimeout(() => {
+      if (onLongPress) {
+        onLongPress();
+      }
+    }, 600); // 600ms for long press
+  };
+
+  const handleMouseUp = () => {
+    clearTimeout(longPressTimer);
+  };
+
+  const handleTouchStart = () => {
+    longPressTimer = setTimeout(() => {
+      if (onLongPress) {
+        onLongPress();
+      }
+    }, 600);
+  };
+
+  const handleTouchEnd = () => {
+    clearTimeout(longPressTimer);
+  };
+
+  // Prevent context menu on long press if it's also a right click
+  const handleContextMenu = (e) => {
+    if (onLongPress) { // If long press is handled, prevent context menu
+        // This is a simple check; more sophisticated logic might be needed
+        // if right-click initiated long press should still show context menu.
+        // For now, assume long press takes precedence for triggering actions.
+        e.preventDefault();
+    }
+  };
+
+
+  return (
+    <button
+      className="folder-chip"
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onContextMenu={handleContextMenu}
+      onKeyDown={(e) => {
+        if (e.key === 'Delete' || e.key === 'Backspace') {
+          if (onLongPress) { // Assuming onLongPress is the delete handler
+            e.preventDefault(); // Prevent browser back navigation on Backspace
+            onLongPress();
+          }
+        }
+        // Allow Enter/Space to also trigger click for accessibility with role="tab"
+        if (e.key === 'Enter' || e.key === ' ') {
+            if(onClick) {
+                e.preventDefault();
+                onClick();
+            }
+        }
+      }}
+      aria-label={`${name} folder, ${count} entries`}
+      role="tab" // As per spec
+      tabIndex={0} // Make it focusable
+    >
+      <div className="folder-chip-name">{name}</div>
+      <div className="folder-chip-count">{count}</div>
+    </button>
+  );
+};
+
+export default FolderChip;

--- a/lune-interface/client/src/components/ui/FolderChip.stories.js
+++ b/lune-interface/client/src/components/ui/FolderChip.stories.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import FolderChip from './FolderChip';
+
+export default {
+  title: 'Components/UI/FolderChip',
+  component: FolderChip,
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: 'text',
+      description: 'Name of the folder',
+    },
+    count: {
+      control: 'number',
+      description: 'Number of entries in the folder',
+    },
+    onClick: { action: 'clicked', description: 'Single click handler' },
+    onDoubleClick: { action: 'doubleClicked', description: 'Double click handler' },
+    onLongPress: { action: 'longPressed', description: 'Long press handler (600ms)' },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '20px', display: 'flex', gap: '20px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Default = {
+  args: {
+    name: 'Notes',
+    count: 12,
+  },
+};
+
+export const LongName = {
+  args: {
+    name: 'Very Long Folder Name That Should Truncate',
+    count: 5,
+  },
+};
+
+export const ZeroCount = {
+  args: {
+    name: 'Empty',
+    count: 0,
+  },
+};
+
+export const ManyEntries = {
+  args: {
+    name: 'Archive',
+    count: 999,
+  },
+};
+
+// Example to test interactions in Storybook
+export const InteractiveChip = (args) => <FolderChip {...args} />;
+InteractiveChip.args = {
+  name: 'Interact',
+  count: 7,
+  onClick: () => alert('Single Clicked!'),
+  onDoubleClick: () => alert('Double Clicked!'),
+  onLongPress: () => alert('Long Pressed!'),
+};

--- a/lune-interface/client/src/components/ui/FolderChip.test.js
+++ b/lune-interface/client/src/components/ui/FolderChip.test.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import FolderChip from './FolderChip';
+
+// Mock CSS import
+jest.mock('./FolderChip.css', () => ({}));
+expect.extend(toHaveNoViolations);
+
+describe('FolderChip', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('renders with name and count and has no a11y violations', async () => {
+    const { container } = render(<FolderChip name="My Notes" count={15} />);
+    expect(screen.getByText('My Notes')).toBeInTheDocument();
+    expect(screen.getByText('15')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /My Notes folder, 15 entries/i})).toBeInTheDocument();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('calls onClick handler when clicked', () => {
+    const handleClick = jest.fn();
+    render(<FolderChip name="Test" count={1} onClick={handleClick} />);
+    fireEvent.click(screen.getByRole('tab'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onDoubleClick handler when double clicked', () => {
+    const handleDoubleClick = jest.fn();
+    render(<FolderChip name="Test" count={1} onDoubleClick={handleDoubleClick} />);
+    fireEvent.doubleClick(screen.getByRole('tab'));
+    expect(handleDoubleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls onLongPress handler after 600ms mousedown without mouseup', () => {
+    const handleLongPress = jest.fn();
+    render(<FolderChip name="Test" count={1} onLongPress={handleLongPress} />);
+    const chip = screen.getByRole('tab');
+
+    fireEvent.mouseDown(chip);
+    act(() => {
+      jest.advanceTimersByTime(599);
+    });
+    expect(handleLongPress).not.toHaveBeenCalled(); // Not yet
+
+    act(() => {
+      jest.advanceTimersByTime(1); // Total 600ms
+    });
+    expect(handleLongPress).toHaveBeenCalledTimes(1);
+
+    // Mouse up should clear timer and not call it again
+    fireEvent.mouseUp(chip);
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(handleLongPress).toHaveBeenCalledTimes(1); // Still 1
+  });
+
+  test('does not call onLongPress if mouseup occurs before 600ms', () => {
+    const handleLongPress = jest.fn();
+    render(<FolderChip name="Test" count={1} onLongPress={handleLongPress} />);
+    const chip = screen.getByRole('tab');
+
+    fireEvent.mouseDown(chip);
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    fireEvent.mouseUp(chip);
+    act(() => {
+      jest.advanceTimersByTime(300); // Advance past 600ms total
+    });
+    expect(handleLongPress).not.toHaveBeenCalled();
+  });
+
+  test('calls onLongPress with touch events', () => {
+    const handleLongPress = jest.fn();
+    render(<FolderChip name="Test" count={1} onLongPress={handleLongPress} />);
+    const chip = screen.getByRole('tab');
+
+    fireEvent.touchStart(chip);
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(handleLongPress).toHaveBeenCalledTimes(1);
+    fireEvent.touchEnd(chip);
+  });
+
+  test('is focusable and has correct ARIA role', () => {
+    render(<FolderChip name="Focus Test" count={3} />);
+    const chip = screen.getByRole('tab', { name: /Focus Test folder, 3 entries/i });
+    chip.focus();
+    expect(chip).toHaveFocus();
+  });
+
+  test('prevents context menu if onLongPress is defined', () => {
+    const onLongPress = jest.fn();
+    render(<FolderChip name="Test" count={1} onLongPress={onLongPress} />);
+    const chip = screen.getByRole('tab');
+    const contextMenuEvent = fireEvent.contextMenu(chip);
+    expect(contextMenuEvent.defaultPrevented).toBe(true);
+  });
+
+  test('does not prevent context menu if onLongPress is not defined', () => {
+    render(<FolderChip name="Test" count={1} />);
+    const chip = screen.getByRole('tab');
+    const contextMenuEvent = fireEvent.contextMenu(chip);
+    expect(contextMenuEvent.defaultPrevented).toBe(false);
+  });
+
+});

--- a/lune-interface/client/src/components/ui/PrimaryButton.css
+++ b/lune-interface/client/src/components/ui/PrimaryButton.css
@@ -1,0 +1,37 @@
+.primary-button {
+  background-color: var(--brazen-gold);
+  color: var(--ink-black); /* Chosen for contrast with Brazen Gold */
+  padding: 10px 20px;
+  border: none;
+  border-radius: 8px; /* A common modern radius */
+  font-family: 'Inter', sans-serif; /* Ensure consistent font */
+  font-weight: 600; /* Slightly bolder text */
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease-out, background-color 0.2s ease-out;
+  text-decoration: none; /* In case it's used as a link styled as a button */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  transform: scale(1.04);
+  /* Consider a slightly darker/lighter shade on hover for accessibility if scale alone is not enough */
+  /* background-color: darken(var(--brazen-gold), 5%); */ /* Example, needs actual color adjustment */
+}
+
+.primary-button:active {
+  transform: scale(0.98); /* Click feedback */
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .primary-button:hover,
+  .primary-button:focus-visible {
+    transform: none; /* Disable scaling */
+  }
+  .primary-button:active {
+    transform: none; /* Disable click feedback scaling */
+  }
+}

--- a/lune-interface/client/src/components/ui/PrimaryButton.jsx
+++ b/lune-interface/client/src/components/ui/PrimaryButton.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import './PrimaryButton.css';
+
+const PrimaryButton = ({ children, onClick, type = 'button', ...props }) => {
+  return (
+    <button
+      type={type}
+      className="primary-button"
+      onClick={onClick}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default PrimaryButton;

--- a/lune-interface/client/src/components/ui/PrimaryButton.stories.js
+++ b/lune-interface/client/src/components/ui/PrimaryButton.stories.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PrimaryButton from './PrimaryButton';
+
+export default {
+  title: 'Components/UI/PrimaryButton',
+  component: PrimaryButton,
+  tags: ['autodocs'], // Enables automatic documentation generation
+  argTypes: {
+    children: {
+      control: 'text',
+      description: 'Button content (text or JSX elements)',
+    },
+    onClick: {
+      action: 'clicked',
+      description: 'Optional click handler',
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['button', 'submit', 'reset'],
+      description: 'Button type attribute',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the button is disabled',
+    }
+  },
+};
+
+// Default story
+export const Default = {
+  args: {
+    children: 'Click Me',
+  },
+};
+
+// Story with custom text
+export const AddFolder = {
+  args: {
+    children: 'Add Folder +',
+  },
+};
+
+// Story for a disabled button
+export const Disabled = {
+  args: {
+    children: 'Cannot Click',
+    disabled: true,
+  },
+};
+
+// Story to showcase with an icon (assuming icon would be passed as children)
+export const WithIcon = {
+  args: {
+    children: (
+      <>
+        <span role="img" aria-label="icon" style={{ marginRight: '8px' }}>➕</span>
+        Add Item
+      </>
+    ),
+  },
+};

--- a/lune-interface/client/src/components/ui/PrimaryButton.test.js
+++ b/lune-interface/client/src/components/ui/PrimaryButton.test.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import PrimaryButton from './PrimaryButton';
+
+// Mock the CSS import
+jest.mock('./PrimaryButton.css', () => ({}));
+expect.extend(toHaveNoViolations);
+
+describe('PrimaryButton', () => {
+  test('renders with children and has no a11y violations', async () => {
+    const { container } = render(<PrimaryButton>Test Button</PrimaryButton>);
+    expect(screen.getByRole('button', { name: /Test Button/i })).toBeInTheDocument();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  test('calls onClick handler when clicked', () => {
+    const handleClick = jest.fn();
+    render(<PrimaryButton onClick={handleClick}>Click Me</PrimaryButton>);
+    fireEvent.click(screen.getByRole('button', { name: /Click Me/i }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('applies type attribute correctly', () => {
+    render(<PrimaryButton type="submit">Submit</PrimaryButton>);
+    expect(screen.getByRole('button', { name: /Submit/i })).toHaveAttribute('type', 'submit');
+  });
+
+  test('defaults to type="button" if no type is provided', () => {
+    render(<PrimaryButton>Default Type</PrimaryButton>);
+    expect(screen.getByRole('button', { name: /Default Type/i })).toHaveAttribute('type', 'button');
+  });
+
+  test('is focusable and can be triggered by keyboard', () => {
+    const handleClick = jest.fn();
+    render(<PrimaryButton onClick={handleClick}>Focus Me</PrimaryButton>);
+    const button = screen.getByRole('button', { name: /Focus Me/i });
+
+    button.focus();
+    expect(button).toHaveFocus();
+
+    // Simulate pressing Enter
+    fireEvent.keyDown(button, { key: 'Enter', code: 'Enter' });
+    // fireEvent.keyUp(button, { key: 'Enter', code: 'Enter' }); // Keyup might also be needed depending on exact event handling
+    // Note: fireEvent.click() is generally preferred for simulating user clicks regardless of input type.
+    // However, testing keyboard interaction specifically for 'Enter' can be done this way.
+    // For buttons, 'Enter' and 'Space' typically trigger a click event.
+    // Let's verify the click handler was called due to keyboard interaction.
+    // Re-clicking via fireEvent.click to ensure the handler is the one being checked
+    // This test primarily ensures focusability. Actual keyboard 'click' is complex.
+    // A simple check for click is better:
+    fireEvent.click(button); // Simulates a generic click
+    expect(handleClick).toHaveBeenCalledTimes(1); //This click is from fireEvent.click above
+
+    // To be more specific about keyboard:
+    const keyboardClick = jest.fn();
+    render(<PrimaryButton onClick={keyboardClick}>Keyboard Click</PrimaryButton>);
+    const kbdButton = screen.getByRole('button', { name: /Keyboard Click/i });
+    kbdButton.focus();
+    fireEvent.keyDown(kbdButton, {key: ' ', code: 'Space'}); // Space bar
+    fireEvent.keyUp(kbdButton, {key: ' ', code: 'Space'});
+    expect(keyboardClick).toHaveBeenCalledTimes(1);
+
+
+  });
+
+  test('passes through other HTML button attributes', () => {
+    render(<PrimaryButton aria-label="Custom Action">Aria Button</PrimaryButton>);
+    expect(screen.getByRole('button', { name: /Aria Button/i })).toHaveAttribute('aria-label', 'Custom Action');
+  });
+
+  test('is disabled when disabled prop is true', () => {
+    const handleClick = jest.fn();
+    render(<PrimaryButton onClick={handleClick} disabled>Disabled Button</PrimaryButton>);
+    const button = screen.getByRole('button', { name: /Disabled Button/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  // Testing :hover or :focus-visible for transform: scale(1.04) is not straightforward
+  // with Jest and RTL for styles applied via external CSS pseudo-classes.
+  // This would typically be covered by visual regression tests or Storybook interaction tests.
+  // We can ensure the button is focusable, which is a prerequisite for :focus-visible.
+  test('receives focus', () => {
+    render(<PrimaryButton>Focus Test</PrimaryButton>);
+    const button = screen.getByRole('button', { name: /Focus Test/i });
+    button.focus();
+    expect(button).toHaveFocus();
+  });
+
+});

--- a/lune-interface/client/src/hooks/.gitkeep
+++ b/lune-interface/client/src/hooks/.gitkeep
@@ -1,0 +1,1 @@
+# Directory for custom hooks

--- a/lune-interface/client/src/hooks/useKeyboardShortcuts.js
+++ b/lune-interface/client/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+
+/**
+ * Custom hook for handling global keyboard shortcuts.
+ * @param {Object} shortcuts - An object where keys are shortcut keys (e.g., 'n', 'b')
+ *                             and values are callback functions to execute.
+ * @param {Array<string>} targetIds - An object mapping shortcut keys to element IDs.
+ *                                    Example: { n: 'add-folder-button', b: 'back-to-chat-button' }
+ */
+const useKeyboardShortcuts = (targetIds = {}) => {
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      const activeElement = document.activeElement;
+      const isTyping =
+        activeElement &&
+        (activeElement.tagName === 'INPUT' ||
+          activeElement.tagName === 'TEXTAREA' ||
+          activeElement.tagName === 'SELECT' ||
+          activeElement.isContentEditable);
+
+      if (isTyping) {
+        return;
+      }
+
+      const key = event.key.toLowerCase();
+
+      if (key === 'n' && targetIds.n) {
+        event.preventDefault();
+        const addFolderBtn = document.getElementById(targetIds.n);
+        if (addFolderBtn) {
+          addFolderBtn.click();
+          addFolderBtn.focus();
+        } else {
+          console.warn(`Button with id "${targetIds.n}" not found for 'n' shortcut.`);
+        }
+      } else if (key === 'b' && targetIds.b) {
+        event.preventDefault();
+        const backToChatBtn = document.getElementById(targetIds.b);
+        if (backToChatBtn) {
+          backToChatBtn.click();
+          // backToChatBtn.focus(); // Optional: focus after click
+        } else {
+          console.warn(`Button with id "${targetIds.b}" not found for 'b' shortcut.`);
+        }
+      }
+      // 'Delete' and 'Backspace' are handled by the focused components themselves (FolderChip, EntryCard)
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [targetIds]); // Re-run effect if targetIds change, though typically they won't.
+};
+
+export default useKeyboardShortcuts;

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -1,9 +1,12 @@
+@import "./styles/tokens.css";
+@import "./styles/motion.css";
+
 /* shadcn/ui theme variables and custom variants */
 
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  --background: #070711; /* Deepest-navy base */
+  /* --background: #070711; */ /* Deepest-navy base - Will be overridden by new gradient */
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -121,35 +124,43 @@
 /* Shadcn base layer customizations AFTER variables are defined and AFTER @tailwind base */
 @layer base {
   * {
-    @apply border-border outline-ring/50; /* Now border-border should be defined */
+    @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    /* @apply bg-background text-foreground; */ /* Replaced by body::before and direct body styles */
+    @apply text-foreground; /* Keep text-foreground from shadcn */
+    font-family: 'Inter', sans-serif; /* Set base body font */
+    color: var(--moon-mist); /* Default text color from our tokens */
+    min-height: 100vh;
+    margin: 0;
+  }
+
+  h1, h2, h3 {
+    font-family: 'Playfair Display', serif;
+    font-weight: 600; /* Corresponds to semibold */
+    color: var(--moon-mist); /* Default heading color, can be overridden */
   }
 }
 
-/* Original app styles */
+/* Original app styles - modified for new design */
 
-/* Lune Diary – mirrored sky band */
+/* Loon Diary Background */
 body::before {
   content: "";
   position: fixed;
-  inset: 0;                         /* cover entire viewport */
-  background:
-    /* top third */
-    linear-gradient(to bottom, rgba(91,33,182,0.25) 0%, transparent 70%) top / 100% 33% no-repeat,
-    /* bottom third */
-    linear-gradient(to top,   rgba(91,33,182,0.25) 0%, transparent 70%) bottom / 100% 33% no-repeat,
-    /* subtle radial halo */
-    radial-gradient(ellipse at 50% 350px, #5b21b6 15%, transparent 60%);
-  pointer-events: none;             /* don’t block clicks */
-  z-index: -1;                      /* sit behind everything */
+  inset: 0;
+  background: radial-gradient(ellipse at center, var(--violet-deep) 0%, var(--ink-black) 70%);
+  pointer-events: none;
+  z-index: -1;
 }
 
+/* The old body rule below is no longer needed as font-family is in @layer base, and color is also set there. */
+/*
 body {
   color: #f8f8f2;
   font-family: 'IBM Plex Sans', sans-serif;
 }
+*/
 
 /* Utility to hide scrollbars while preserving scroll ability */
 .no-scrollbar::-webkit-scrollbar {

--- a/lune-interface/client/src/styles/motion.css
+++ b/lune-interface/client/src/styles/motion.css
@@ -1,0 +1,14 @@
+/* CSS Animations and Transitions for Loon Diary */
+
+@keyframes pulse-loop-dot {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% { /* Mid-point of the pulse */
+    transform: scale(1.3);
+    opacity: 0.7; /* Optional: slightly fade at peak for softer pulse */
+  }
+}
+
+/* preferes-reduced-motion will be added later as per plan */

--- a/lune-interface/client/src/styles/tokens.css
+++ b/lune-interface/client/src/styles/tokens.css
@@ -1,0 +1,43 @@
+/* CSS Color Tokens for Loon Diary */
+:root {
+  --violet-deep: #5B2EFF;
+  --ink-black: #050409;
+  --moon-mist: #E9E7FF;
+  --brazen-gold: #F3B43F;
+  --ember-red: #FF4455;
+  --aqua-loop: #22D4C5;
+
+  /* RGB versions for use in rgba() */
+  --violet-deep-rgb: 91, 46, 255;
+  --ink-black-rgb: 5, 4, 9;
+  --moon-mist-rgb: 233, 231, 255;
+  --brazen-gold-rgb: 243, 180, 63;
+  --ember-red-rgb: 255, 68, 85;
+  --aqua-loop-rgb: 34, 212, 197;
+}
+
+/*
+  Font Definitions for Loon Diary
+  Ideally, these would be .woff2 format for better compression.
+  The view_text_website tool currently retrieves .ttf from Google Fonts.
+  These should be updated to .woff2 if a different method for fetching
+  Google Fonts CSS is available or if fonts are self-hosted.
+*/
+
+/* Inter Regular */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/inter/v19/UcCO3FwrK3iLTeHuS_nVMrMxCp50SjIw2boKoduKmMEVuLyfMZg.ttf) format('truetype');
+}
+
+/* Playfair Display Semibold */
+@font-face {
+  font-family: 'Playfair Display';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/playfairdisplay/v39/nuFvD-vYSZviVYUb_rj3ij__anPXJzDwcbmjWBN2PKebukDQ.ttf) format('truetype');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,102 @@
     "": {
       "dependencies": {
         "framer-motion": "^12.23.0"
+      },
+      "devDependencies": {
+        "jest-axe": "^10.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/framer-motion": {
@@ -35,6 +131,81 @@
         }
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-axe": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-10.0.0.tgz",
+      "integrity": "sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axe-core": "4.10.2",
+        "chalk": "4.1.2",
+        "jest-matcher-utils": "29.2.2",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.2.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
+      "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.2.1",
+        "jest-get-type": "^29.2.0",
+        "pretty-format": "^29.2.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/motion-dom": {
       "version": "12.22.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.22.0.tgz",
@@ -49,6 +220,54 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
       "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
       "license": "MIT"
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "framer-motion": "^12.23.0"
+  },
+  "devDependencies": {
+    "jest-axe": "^10.0.0"
   }
 }


### PR DESCRIPTION
Implements the new Loon Diary "Entries" experience as specified in the Visual & Interaction Guide v0.2.1.

Key features include:
- Global theme with CSS color tokens and typography (Playfair Display, Inter).
- Atomic UI components: PrimaryButton, FolderChip, EntryCard, BackToChatButton.
  - Components include specified styling, hover/active states, ARIA roles, and prefers-reduced-motion fallbacks.
  - Storybook stories and Jest/RTL tests (including jest-axe) created.
- EntriesPage composition:
  - Sticky, scrollable FoldersRibbon (responsive with scroll-snap).
  - Responsive DiaryFeed for EntryCards.
  - EntryCard loop-dot pulse animation and page slide-out on click.
  - "Add Folder +" button in header.
  - Scroll-triggered fade-in for "Back to Chat" button.
- Keyboard shortcuts:
  - 'n' (new folder), 'b' (back-to-chat) via custom hook.
  - 'Delete' key for focused items handled by components.
- Accessibility: jest-axe integrated, color contrast considered.