### PR TITLE
Update All-Entries page typography, micro-copy, and BackToChatButton

### DIFF
--- a/lune-interface/client/src/App.css
+++ b/lune-interface/client/src/App.css
@@ -23,9 +23,7 @@
   font-size: calc(10px + 2vmin);
   color: white;
 }
-body {
-  font-family: 'Inter', sans-serif;
-}
+
 .App-link {
   color: #61dafb;
 }

--- a/lune-interface/client/src/components/DiaryInput.jsx
+++ b/lune-interface/client/src/components/DiaryInput.jsx
@@ -56,7 +56,7 @@ const DiaryInput = ({ onSave, initialText = '', clearOnSave = false }) => {
       <textarea
         ref={textareaRef}
         rows={1}
-        placeholder="Write what’s on your mind…"
+        placeholder="Write what stirs beneath …"
         value={text}
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}

--- a/lune-interface/client/src/components/EntriesPage.css
+++ b/lune-interface/client/src/components/EntriesPage.css
@@ -26,9 +26,9 @@
 .entries-page-title {
   color: var(--lunePurple, #7C3AED); /* Fallback color */
   font-size: 1.875rem; /* Equivalent to text-3xl */
-  font-weight: 700; /* Equivalent to font-bold */
-  font-family: 'Literata', serif; /* Assuming font-literata */
-  font-weight: 300; /* Equivalent to font-light */
+  /* font-weight is handled by global H1 style in index.css */
+  font-family: 'Playfair Display', 'Times New Roman', serif; /* As per request */
+  letter-spacing: -0.5px; /* As per request */
   /* text-center was on the h1, but header is flex justify-between, so text-center on title itself might not be needed */
 }
 
@@ -51,11 +51,22 @@
 }
 
 .entries-page-section-title {
-  font-size: 1.25rem; /* text-xl */
+  font-family: 'Inter', sans-serif;
+  font-weight: 500; /* Medium */
+  font-size: 1.05rem;
+  line-height: 1.55;
+  letter-spacing: -0.1px;
   color: var(--luneLightGray, #D1D5DB); /* Fallback */
   margin-bottom: 0.75rem; /* mb-3 */
-  font-family: 'Literata', serif;
-  font-weight: 300;
+}
+
+.folder-label-style { /* For text within Folder.js component */
+  font-family: 'Inter', sans-serif;
+  font-weight: 500; /* Medium */
+  font-size: 1.05rem;
+  line-height: 1.55; /* This might be tight for multi-line folder names in small circles, adjust if needed */
+  letter-spacing: -0.1px;
+  /* color: inherit; /* Or set explicitly if needed */
 }
 
 .entries-page-folders-grid {
@@ -107,6 +118,11 @@
 }
 
 .entries-page-empty-message {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500; /* Medium */
+  font-size: 1.05rem;
+  line-height: 1.55;
+  letter-spacing: -0.1px;
   text-align: center;
   color: var(--slate-300, #D1D5DB); /* Fallback */
   padding: 1rem;

--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -3,10 +3,15 @@ import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import Folder from './Folder';
 import EntryCard from './ui/EntryCard'; // Import EntryCard
+import BackToChatButton from './ui/BackToChatButton'; // Import the new button
 import './EntriesPage.css'; // Import specific styles for EntriesPage if any are still needed (e.g., layout)
 
 export default function EntriesPage({ entries, folders, refreshEntries, refreshFolders, startEdit }) {
   const navigate = useNavigate();
+
+  const handleBackToChat = () => {
+    navigate('/chat');
+  };
 
   // handleDelete is now passed to EntryCard, which calls it with entryId
   const handleDeleteEntry = async (id) => {
@@ -134,15 +139,16 @@ export default function EntriesPage({ entries, folders, refreshEntries, refreshF
               />
             </div>
           ))}
-          {entries.length === 0 && <div className="entries-page-empty-message">No entries.</div>}
+          {entries.length === 0 && <div className="entries-page-empty-message">Every echo has found its nest.</div>}
           {entries.length > 0 && unfiledEntries.length === 0 && folders.length > 0 && (
-            <div className="entries-page-empty-message">All entries are in folders.</div>
+            <div className="entries-page-empty-message">This space awaits a new ripple.</div>
           )}
            {entries.length > 0 && unfiledEntries.length === 0 && folders.length === 0 && (
-            <div className="entries-page-empty-message">No unfiled entries. Add some or check folders.</div>
+            <div className="entries-page-empty-message">This space awaits a new ripple.</div>
           )}
         </div>
-        <button onClick={() => navigate('/chat')} className="entries-page-back-link">Back to Chat</button>
+        {/* Replace the old button with the new BackToChatButton component */}
+        <BackToChatButton id="entries-page-back-to-chat" onClick={handleBackToChat} />
       </div>
     </main>
   );

--- a/lune-interface/client/src/components/EntriesPage.test.js
+++ b/lune-interface/client/src/components/EntriesPage.test.js
@@ -46,6 +46,14 @@ jest.mock('./ui/BackToChatButton.css', () => ({}));
 jest.mock('./EntriesPage.css', () => ({}));
 jest.mock('../styles/motion.css', () => ({}));
 
+// Mock BackToChatButton as it has its own complex logic and tests
+jest.mock('./ui/BackToChatButton', () => ({ id, onClick }) => (
+  <button id={id} onClick={onClick} aria-label="Return to the moment">
+    <span aria-hidden="true">↩</span>
+    <span>Back to Chat</span> {/* Visual text, aria-label is for screen readers */}
+  </button>
+));
+
 
 expect.extend(toHaveNoViolations);
 
@@ -84,7 +92,10 @@ describe('EntriesPage', () => {
     expect(screen.getByRole('tablist', { name: /Folder categories/i })).toBeInTheDocument();
     expect(screen.getByRole('list', { name: /Diary entries/i })).toBeInTheDocument();
     expect(screen.getByText(mockInitialEntries[0].title)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Back to Chat/i })).toHaveAttribute('id', 'back-to-chat-button');
+    // Updated to reflect the mocked BackToChatButton's aria-label and the new ID passed from EntriesPage
+    const backButton = screen.getByRole('button', { name: /Return to the moment/i });
+    expect(backButton).toBeInTheDocument();
+    expect(backButton).toHaveAttribute('id', 'entries-page-back-to-chat'); // ID passed from EntriesPage
 
     const results = await axe(container);
     expect(results).toHaveNoViolations();
@@ -206,7 +217,8 @@ describe('EntriesPage', () => {
 
   test('handles "Back to Chat" button click via direct click', () => {
     render(<EntriesPage initialEntries={mockInitialEntries} initialFolders={mockInitialFolders} />);
-    const backToChatButton = screen.getByRole('button', { name: /Back to Chat/i });
+    // Updated to reflect the mocked BackToChatButton's aria-label
+    const backToChatButton = screen.getByRole('button', { name: /Return to the moment/i });
     fireEvent.click(backToChatButton);
     expect(window.location.href).toBe('/chat');
   });

--- a/lune-interface/client/src/components/Folder.js
+++ b/lune-interface/client/src/components/Folder.js
@@ -42,14 +42,14 @@ const Folder = ({ folder, onDropEntry }) => {
 
   return (
     <div
-      className="rounded-full w-32 h-32 flex flex-col items-center justify-center text-white font-bold text-lg shadow-lg cursor-pointer transition-all duration-300 ease-in-out border-2 hover:shadow-xl hover:scale-105"
+      className="rounded-full w-32 h-32 flex flex-col items-center justify-center text-white shadow-lg cursor-pointer transition-all duration-300 ease-in-out border-2 hover:shadow-xl hover:scale-105"
       style={folderStyle}
       onDragOver={handleDragOver}
       onDrop={handleDrop}
       onClick={handleClick}
       title={`Open folder: ${folder.name} (${entryCount} ${entryCount === 1 ? 'entry' : 'entries'})`}
     >
-      <span className="block text-center break-words max-w-[80%] leading-tight">{folder.name}</span>
+      <span className="folder-label-style block text-center break-words max-w-[80%]">{folder.name}</span>
       <span className="text-xs font-normal mt-1">({entryCount})</span>
     </div>
   );

--- a/lune-interface/client/src/components/ui/BackToChatButton.css
+++ b/lune-interface/client/src/components/ui/BackToChatButton.css
@@ -3,68 +3,74 @@
   bottom: 24px;
   left: 24px;
 
-  /* Glassmorphism styles */
-  background-color: rgba(var(--violet-deep-rgb), 0.12); /* Spec: rgba(91,46,255,.12) bg */
-  border: 1px solid rgba(var(--moon-mist-rgb), 0.3); /* Spec: Moon-Mist 30% border (changed from 2px to 1px for a sleeker look) */
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px); /* For Safari */
+  /* Liquid-glass pill styles */
+  padding: 8px 22px; /* Spec: padding 8 22 */
+  border: 1px solid rgba(var(--moon-mist-rgb, 221, 223, 228), 0.3); /* Moon-Mist @ 30% */
+  background: linear-gradient(110deg, rgba(91,46,255,.20) 0%, rgba(91,46,255,.06) 100%);
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%); /* For Safari */
+  box-shadow: inset 0 0 10px rgba(255,255,255,.12); /* Inner inset glow */
 
-  color: var(--moon-mist); /* Text and icon color on the blurred bg */
-  padding: 6px 18px; /* Spec: pad 6 18 */
+  color: var(--moon-mist, #DDFDE4); /* Text and icon color */
   border-radius: 9999px; /* Pill shape */
   font-family: 'Inter', sans-serif;
-  font-weight: 500; /* Medium weight */
-  font-size: 0.9rem;
+  font-weight: 400; /* Regular weight */
+  font-size: 0.95rem; /* Spec: 0.95rem */
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  z-index: 1000; /* Ensure it's above most content, including other fixed/sticky elements */
+  z-index: 1000;
 
   opacity: 0;
-  transform: translateY(20px); /* Start slightly lower for fade-in effect */
-  transition: opacity 400ms ease-out, transform 400ms ease-out,
-              background-color 0.2s ease-out, border-color 0.2s ease-out;
-  pointer-events: none; /* Not interactive when hidden */
+  transform: translateY(20px);
+  transition: opacity 400ms ease-out, transform 400ms ease-out, filter 0.2s ease-out, box-shadow 0.2s ease-out;
+  pointer-events: none;
   outline: none;
 }
 
 .back-to-chat-button.visible {
   opacity: 1;
   transform: translateY(0);
-  pointer-events: auto; /* Interactive when visible */
+  pointer-events: auto;
 }
 
-.back-to-chat-button:hover,
-.back-to-chat-button:focus-visible {
-  background-color: rgba(var(--violet-deep-rgb), 0.25); /* Slightly more opaque violet on hover */
-  border-color: rgba(var(--moon-mist-rgb), 0.5); /* Brighter border on hover */
-  color: var(--moon-mist); /* Keep text color */
-  outline: none; /* Ensure no default outline interferes with custom styling */
+.back-to-chat-button:hover {
+  filter: brightness(1.15);
 }
-/* Specific focus-visible style for accessibility if different from hover */
+
+.back-to-chat-button:active {
+  transform: scale(0.97) translateY(0); /* Keep translateY(0) from .visible state */
+  filter: brightness(1.15); /* Keep hover brightness during active state */
+}
+
+/* Specific focus-visible style for accessibility */
 .back-to-chat-button:focus-visible {
-  outline: 2px solid var(--aqua-loop); /* Example focus outline */
+  outline: 2px solid var(--aqua-loop, #00FFFF); /* Example focus outline, ensure --aqua-loop is defined */
   outline-offset: 2px;
+  filter: brightness(1.15); /* Apply hover brightness on focus as well */
 }
-
 
 .back-to-chat-icon {
-  font-size: 1.2em; /* Make icon slightly larger than text */
-  line-height: 1; /* Prevent extra spacing */
+  font-size: 1.2em;
+  line-height: 1;
 }
 
-/* Text part can be hidden on very small screens if needed, or icon only */
-/* .back-to-chat-text { ... } */
-
-/* Reduced motion: just fade, no transform */
+/* Reduced motion adjustments */
 @media (prefers-reduced-motion: reduce) {
   .back-to-chat-button {
-    transform: translateY(0); /* No translate, just fade */
-    transition: opacity 400ms ease-out, background-color 0.2s ease-out, border-color 0.2s ease-out;
+    transform: translateY(0);
+    transition: opacity 400ms ease-out, filter 0.2s ease-out, box-shadow 0.2s ease-out;
+    /* Motion safety: remove blur and use a more solid background */
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: rgba(var(--violet-deep-rgb, 91, 46, 255), 0.7); /* Example: Use a solid, slightly transparent version of a theme color */
   }
   .back-to-chat-button.visible {
     transform: translateY(0);
+  }
+  .back-to-chat-button:active {
+    transform: scale(1); /* No scale on active for reduced motion */
   }
 }
 

--- a/lune-interface/client/src/components/ui/BackToChatButton.jsx
+++ b/lune-interface/client/src/components/ui/BackToChatButton.jsx
@@ -14,10 +14,10 @@ const BackToChatButton = ({ id, onClick }) => { // Added id prop for keyboard sh
       }
 
       if (window.scrollY > 100) { // User has scrolled down a bit
-        // Set a timeout to make the button visible after 1 second
+        // Set a timeout to make the button visible after 0.5 seconds
         scrollTimeoutRef.current = setTimeout(() => {
           setIsVisible(true);
-        }, 1000); // Animation starts after 1000ms (1s)
+        }, 500); // Animation starts after 500ms (0.5s)
       } else {
         // If scrolled back to top, hide the button immediately (or after its fade-out animation)
         setIsVisible(false);
@@ -54,7 +54,7 @@ const BackToChatButton = ({ id, onClick }) => { // Added id prop for keyboard sh
       ref={buttonRef}
       className={`back-to-chat-button ${isVisible ? 'visible' : ''}`}
       onClick={handleClick}
-      aria-label="Back to Chat"
+      aria-label="Return to the moment" // Updated aria-label
       // aria-hidden={!isVisible} // Hide from screen readers when not visible
       // pointer-events are handled by CSS, so aria-hidden might be redundant if CSS fully hides it.
     >

--- a/lune-interface/client/src/components/ui/BackToChatButton.test.js
+++ b/lune-interface/client/src/components/ui/BackToChatButton.test.js
@@ -30,7 +30,7 @@ describe('BackToChatButton', () => {
 
   test('renders button with correct id, text, icon, and has no a11y violations initially hidden', async () => {
     const { container } = render(<BackToChatButton id={buttonId} />);
-    const button = screen.getByRole('button', { name: /Back to Chat/i });
+    const button = screen.getByRole('button', { name: /Return to the moment/i }); // Updated name
     expect(button).toBeInTheDocument();
     expect(button).toHaveAttribute('id', buttonId);
     expect(screen.getByText('↩')).toBeInTheDocument(); // Icon
@@ -40,20 +40,20 @@ describe('BackToChatButton', () => {
     expect(results).toHaveNoViolations();
   });
 
-  test('becomes visible after scrolling >100px and 1000ms delay, and has no a11y violations when visible', async () => {
+  test('becomes visible after scrolling >100px and 500ms delay, and has no a11y violations when visible', async () => {
     const { container } = render(<BackToChatButton id={buttonId} />);
-    const button = screen.getByRole('button', { name: /Back to Chat/i });
+    const button = screen.getByRole('button', { name: /Return to the moment/i }); // Updated name
 
     expect(button).not.toHaveClass('visible');
 
     // Simulate scroll down
     act(() => { simulateScroll(200); });
 
-    // Advance time by 999ms
-    act(() => { jest.advanceTimersByTime(999); });
+    // Advance time by 499ms
+    act(() => { jest.advanceTimersByTime(499); });
     expect(button).not.toHaveClass('visible'); // Still not visible
 
-    // Advance time by 1ms to cross the 1000ms threshold
+    // Advance time by 1ms to cross the 500ms threshold
     act(() => { jest.advanceTimersByTime(1); });
     expect(button).toHaveClass('visible');
 
@@ -65,12 +65,12 @@ describe('BackToChatButton', () => {
   test('calls onClick handler when clicked (after becoming visible)', () => {
     const handleClick = jest.fn();
     render(<BackToChatButton id={buttonId} onClick={handleClick} />);
-    const button = screen.getByRole('button', { name: /Back to Chat/i });
+    const button = screen.getByRole('button', { name: /Return to the moment/i }); // Updated name
 
     // Make it visible
     act(() => {
       simulateScroll(200);
-      jest.advanceTimersByTime(1000); // Advance by the full delay
+      jest.advanceTimersByTime(500); // Advance by the full delay
     });
     expect(button).toHaveClass('visible');
 
@@ -80,12 +80,12 @@ describe('BackToChatButton', () => {
 
   test('hides again when scrolled to top (scrollY <= 100)', () => {
     render(<BackToChatButton id={buttonId} />);
-    const button = screen.getByRole('button', { name: /Back to Chat/i });
+    const button = screen.getByRole('button', { name: /Return to the moment/i }); // Updated name
 
     // Make it visible
     act(() => {
       simulateScroll(200);
-      jest.advanceTimersByTime(1000);
+      jest.advanceTimersByTime(500); // Updated delay
     });
     expect(button).toHaveClass('visible');
 


### PR DESCRIPTION
- Updates H1 and body typography on the All-Entries page (EntriesPage.js, EntriesPage.css, Folder.js) to use Playfair Display and Inter respectively, with specified sizings and letter-spacing.
- Refreshes micro-copy for empty states on All-Entries page.
- Updates textarea placeholder in DiaryInput.jsx on the chat page.
- Replaces plain 'Back to Chat' link on EntriesPage with a new liquid-glass pill BackToChatButton component.
- Styles BackToChatButton with new design language: fixed position, padding, border, gradient background, backdrop-filter, inner glow, Inter font, and hover/active effects.
- Updates BackToChatButton to fade in after 0.5s scroll and sets aria-label to 'Return to the moment'.
- Provides motion-safe fallbacks for blur effects and animations.
- Updates jest-axe tests for EntriesPage and BackToChatButton to reflect changes and ensure accessibility.