### PR TITLE
fix: Update EntriesPage UX

### DIFF
--- a/lune-interface/client/src/components/EntriesPage.css
+++ b/lune-interface/client/src/components/EntriesPage.css
@@ -6,15 +6,19 @@
 
 .entries-page-content {
   padding: 1rem; /* Equivalent to p-4 */
+  /*
   opacity: 0;
   animation: fadeIn 0.7s ease-in-out forwards; /* Existing animation */
+  */
 }
 
+/*
 @keyframes fadeIn {
   to {
     opacity: 1;
   }
 }
+*/
 
 .entries-page-header {
   display: flex;

--- a/lune-interface/client/src/components/ui/BackToChatButton.jsx
+++ b/lune-interface/client/src/components/ui/BackToChatButton.jsx
@@ -1,43 +1,10 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useRef } from 'react'; // Removed useState, useEffect
 import PropTypes from 'prop-types';
 import './BackToChatButton.css';
 
 const BackToChatButton = ({ id, onClick }) => { // Added id prop for keyboard shortcut targeting
-  const [isVisible, setIsVisible] = useState(false);
   const buttonRef = useRef(null);
-  const scrollTimeoutRef = useRef(null);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      // Clear any existing timeout to avoid multiple fade-ins if user scrolls up/down quickly
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-
-      if (window.scrollY > 100) { // User has scrolled down a bit
-        // Set a timeout to make the button visible after 0.5 seconds
-        scrollTimeoutRef.current = setTimeout(() => {
-          setIsVisible(true);
-        }, 500); // Animation starts after 500ms (0.5s)
-      } else {
-        // If scrolled back to top, hide the button immediately (or after its fade-out animation)
-        setIsVisible(false);
-      }
-    };
-
-    // Add scroll listener
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    // Initial check in case page loads already scrolled down
-    handleScroll();
-
-    // Cleanup function to remove listener and clear timeout
-    return () => {
-      window.removeEventListener('scroll', handleScroll);
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-    };
-  }, []); // Empty dependency array means this effect runs once on mount and cleans up on unmount
+  // Removed isVisible state and useEffect for scroll handling
 
   const handleClick = () => {
     if (onClick) {
@@ -53,11 +20,11 @@ const BackToChatButton = ({ id, onClick }) => { // Added id prop for keyboard sh
     <button
       id={id} // Apply id for keyboard shortcut targeting
       ref={buttonRef}
-      className={`back-to-chat-button ${isVisible ? 'visible' : ''}`}
+      // Always apply 'visible' class or adjust CSS to not need it for visibility
+      className="back-to-chat-button visible"
       onClick={handleClick}
       aria-label="Return to the moment" // Updated aria-label
-      // aria-hidden={!isVisible} // Hide from screen readers when not visible
-      // pointer-events are handled by CSS, so aria-hidden might be redundant if CSS fully hides it.
+      // No longer need aria-hidden based on isVisible
     >
       <span className="back-to-chat-icon" aria-hidden="true">↩</span>
       <span className="back-to-chat-text">Back to Chat</span>


### PR DESCRIPTION
- Modified BackToChatButton to be always visible by default, removing the scroll-to-reveal behavior for testing and user feedback.
- Disabled the fadeIn animation on EntriesPage content to prevent it from replaying during data refresh operations.