### PR TITLE
Fix: Correct CSS syntax error in EntriesPage.css

### DIFF
--- a/lune-interface/client/src/components/EntriesPage.css
+++ b/lune-interface/client/src/components/EntriesPage.css
@@ -9,7 +9,6 @@
   /*
   opacity: 0;
   animation: fadeIn 0.7s ease-in-out forwards; /* Existing animation */
-  */
 }
 
 /*


### PR DESCRIPTION
Removes an extraneous closing comment '*/' that was causing a compilation failure.