### PR TITLE
Fix: Correct CSS syntax and remove unused variable

### DIFF
--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useNavigate } from 'react-router-dom';
 // LuneChatModal is now imported in App.js
 import HashtagButtons from './HashtagButtons';
 import HashtagEntriesModal from './HashtagEntriesModal'; // Import HashtagEntriesModal
@@ -13,7 +12,6 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
   // const [showChat, setShowChat] = useState(false); // Moved to App.js
   const [isHashtagModalOpen, setIsHashtagModalOpen] = useState(false); // State for hashtag modal
   const [selectedHashtag, setSelectedHashtag] = useState(null); // State for selected hashtag
-  const navigate = useNavigate();
 
   useEffect(() => {
     if (editingId) {

--- a/lune-interface/client/src/components/EntriesPage.css
+++ b/lune-interface/client/src/components/EntriesPage.css
@@ -6,7 +6,6 @@
 
 .entries-page-content {
   padding: 1rem; /* Equivalent to p-4 */
-  /*
   opacity: 0;
   animation: fadeIn 0.7s ease-in-out forwards; /* Existing animation */
 }


### PR DESCRIPTION
- Corrected a CSS comment in EntriesPage.css that caused a build failure.
- Removed an unused `navigate` variable and its corresponding `useNavigate` import from DockChat.js to resolve an ESLint warning.