### PR TITLE
Fix: Revert page background to original, investigate ribbon and folde…

### DIFF
--- a/lune-interface/client/src/components/FoldersRibbon.css
+++ b/lune-interface/client/src/components/FoldersRibbon.css
@@ -20,7 +20,7 @@
   /* Custom thin purple scrollbar for horizontal scrolling - kept as is */
   scrollbar-width: thin; /* Firefox */
   scrollbar-color: #5B2EFF55 transparent; /* Firefox: thumb, track */
-  overflow: hidden; /* Hide stars that go outside the ::before element during rotation */
+  /* overflow: hidden; */ /* Hide stars that go outside the ::before element during rotation - Temporarily commented out for debugging */
 }
 
 @keyframes galaxy-swirl {

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -150,7 +150,7 @@ body::before {
   position: fixed;
   inset: 0;
   /* background: radial-gradient(ellipse at center, var(--violet-deep) 0%, var(--ink-black) 70%); */ /* Old gradient */
-  background: radial-gradient(ellipse at center, rgba(var(--violet-deep-rgb), 0.1) 0%, transparent 70%); /* New page body gradient */
+  /* background: radial-gradient(ellipse at center, rgba(var(--violet-deep-rgb), 0.1) 0%, transparent 70%); */ /* New page body gradient - Commented out */
   pointer-events: none;
   z-index: -1;
 }

--- a/lune-interface/client/src/styles/tokens.css
+++ b/lune-interface/client/src/styles/tokens.css
@@ -63,7 +63,7 @@
 body {
   font-family: 'Inter', sans-serif; /* Default body font */
   color: var(--moon-mist);
-  /* background-color: var(--ink-black); */ /* Removed to allow body::before gradient to show */
+  background-color: var(--ink-black); /* Removed to allow body::before gradient to show */
 }
 
 h1, h2, h3 {


### PR DESCRIPTION
…r chip styles

- Reverted undesired page background change by restoring body background color in tokens.css and commenting out conflicting body::before background in index.css.
- Temporarily commented out 'overflow: hidden' in FoldersRibbon.css to help diagnose issues with the ribbon's star/galaxy effect visibility.
- Reviewed FolderChip CSS and related files (motion.css, FolderChip.jsx); the existing code for animations and styling appears consistent with the intended design. No changes made to FolderChip in this commit.