### PR TITLE
Fix: Restore global radial gradient and add regression test

### DIFF
--- a/lune-interface/client/lune-interface/client/lune-interface/client/lune-interface/client/package-lock.json
+++ b/lune-interface/client/lune-interface/client/lune-interface/client/lune-interface/client/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "client",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/lune-interface/client/lune-interface/client/lune-interface/client/lune-interface/package-lock.json
+++ b/lune-interface/client/lune-interface/client/lune-interface/client/lune-interface/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "lune-interface",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/lune-interface/client/src/App.test.js
+++ b/lune-interface/client/src/App.test.js
@@ -6,3 +6,12 @@ test('renders lune diary heading', () => {
   const headingElement = screen.getByText(/lune diary./i);
   expect(headingElement).toBeInTheDocument();
 });
+
+test('body has the correct radial gradient background', () => {
+  render(<App />);
+  const bodyStyles = window.getComputedStyle(document.body);
+  // Check for the presence of the starting color of the gradient
+  expect(bodyStyles.backgroundImage).toContain('radial-gradient');
+  expect(bodyStyles.backgroundImage).toContain('#5b2eff'); // Hex code for violet-deep, ensure case-insensitivity if necessary
+  // We could also check for the ending color #050409, but starting color is a good indicator.
+});

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -126,12 +126,28 @@
   * {
     @apply border-border outline-ring/50;
   }
+
+  html, body {
+    height: 100%;
+    background: radial-gradient(circle at 50% 40%, #5B2EFF 0%, #050409 60%, #050409 100%);
+    background-attachment: fixed;      /* keeps centre glow static */
+    background-repeat: no-repeat;
+    color-scheme: dark;
+  }
+
+  @media print {
+    html, body {
+      background: none;
+    }
+  }
+
   body {
     /* @apply bg-background text-foreground; */ /* Replaced by body::before and direct body styles */
+    /* Ensure body doesn't override html's height if it was set to min-height only */
     @apply text-foreground; /* Keep text-foreground from shadcn */
     font-family: 'Inter', sans-serif; /* Set base body font */
     color: var(--moon-mist); /* Default text color from our tokens */
-    min-height: 100vh;
+    /* min-height: 100vh; /* Covered by height: 100% on html, body */
     margin: 0;
   }
 
@@ -145,15 +161,18 @@
 /* Original app styles - modified for new design */
 
 /* Loon Diary Background */
+/*
 body::before {
   content: "";
   position: fixed;
   inset: 0;
   /* background: radial-gradient(ellipse at center, var(--violet-deep) 0%, var(--ink-black) 70%); */ /* Old gradient */
   /* background: radial-gradient(ellipse at center, rgba(var(--violet-deep-rgb), 0.1) 0%, transparent 70%); */ /* New page body gradient - Commented out */
+/*
   pointer-events: none;
   z-index: -1;
 }
+*/
 
 /* The old body rule below is no longer needed as font-family is in @layer base, and color is also set there. */
 /*


### PR DESCRIPTION
Restores the intended violet-to-black radial gradient background to html/body. Ensures the gradient is fixed on scroll and respects print media queries.

Removes prefers-reduced-motion query from the gradient as per feedback, as the fixed attachment does not animate.

Adds a Jest test to App.test.js to verify the body's background image, aiding in preventing future regressions where the gradient might be overridden.