### PR TITLE
Fix: Center chat input and tags on writing page

### DIFF
--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -81,7 +81,8 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
   return (
     <main className="relative">
       {/* Removed opacity-0 and animate-fadeIn from the div below */}
-      <div className="p-4 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out">
+      {/* Added flex flex-col items-center to center its children: HashtagButtons and the form */}
+      <div className="p-4 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out flex flex-col items-center">
         <div className="flex gap-2 mb-4">
         </div>
         {/* Hashtag Buttons Area */}


### PR DESCRIPTION
The chat input box (DiaryInput) and the hashtag tags row were not centered after the initial header adjustments.

This commit centers these elements on the page by modifying the main content container in DockChat.js to be a flex column that centers its children.