### PR TITLE
Style: Standardize buttons to Liquid Gold theme

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -115,15 +115,14 @@ function App() {
         </div>
         {isChatPage && (
           <footer className="w-full flex justify-center items-center px-4 pb-6"> {/* Changed pb-10 to pb-6 */}
-            <div className="frost rounded-2xl px-6 py-3">
-              <button
-                type="button"
-                onClick={() => setShowChat(true)} // Use setShowChat from App's state
-                className="px-4 py-2 rounded shadow-md shadow-violet-800/40"
-              >
-                Chat with Lune
-              </button>
-            </div>
+            {/* The div with frost styling has been removed */}
+            <button
+              type="button"
+              onClick={() => setShowChat(true)} // Use setShowChat from App's state
+              className="btn-liquid-gold" // Apply the new class
+            >
+              Chat with Lune
+            </button>
           </footer>
         )}
         <LuneChatModal open={showChat} onClose={() => setShowChat(false)} />

--- a/lune-interface/client/src/components/DiaryInput.jsx
+++ b/lune-interface/client/src/components/DiaryInput.jsx
@@ -65,8 +65,7 @@ const DiaryInput = ({ onSave, initialText = '', clearOnSave = false }) => {
       {/* New button container */}
       <div className="flex items-center gap-4 justify-start mt-3"> {/* 1rem = gap-4, 0.75rem = mt-3 */}
         <Button
-          variant="outline" // Using outline for clear glass effect
-          className="h-8 px-[18px] rounded-xl border-brazen-gold text-brazen-gold hover:bg-brazen-gold/10" // Custom styles for Save button
+          className="btn-liquid-gold" // Apply the new class
           onClick={() => {
             if (onSave) {
               onSave(text);
@@ -79,8 +78,7 @@ const DiaryInput = ({ onSave, initialText = '', clearOnSave = false }) => {
           Save <kbd className="ml-2 text-xs">⌘/Ctrl + ↵</kbd>
         </Button>
         <Button
-          variant="default" // Assuming default is a solid fill
-          className="h-8 px-[18px] rounded-xl bg-violet-600/70 hover:bg-violet-500/70 text-white backdrop-blur-md" // Custom styles for Chat button, using existing violet
+          className="btn-liquid-gold" // Apply the new class
         >
           Chat with Lune
         </Button>

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -122,6 +122,43 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Custom button style for Liquid Gold */
+.btn-liquid-gold {
+  border-radius: 12px;
+  height: 32px;
+  padding: 0 18px;
+  border: 1px solid rgba(var(--brazen-gold-rgb), 0.85);
+  background: linear-gradient(145deg, rgba(var(--brazen-gold-rgb), 0.18) 0%, rgba(var(--brazen-gold-rgb), 0.06) 100%);
+  backdrop-filter: blur(14px) saturate(180%);
+  box-shadow: 0 0 12px 4px rgba(var(--brazen-gold-rgb), 0.22) inset, 0 0 8px rgba(255, 255, 255, 0.12) inset;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600; /* Added for consistency with other buttons, can be adjusted */
+  color: var(--brazen-gold);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none; /* Remove underline if it's an <a> tag styled as button */
+  cursor: pointer;
+  transition: filter 0.2s ease-out, transform 0.2s ease-out, box-shadow 0.2s ease-out; /* Added box-shadow transition */
+}
+
+.btn-liquid-gold:hover {
+  filter: brightness(1.15);
+  /* Optional: slightly enhance shadow on hover if desired */
+  /* box-shadow: 0 0 14px 5px rgba(var(--brazen-gold-rgb), 0.25) inset, 0 0 10px rgba(255,255,255,.15) inset; */
+}
+
+.btn-liquid-gold:active {
+  transform: scale(0.97);
+}
+
+/* Ensure kbd elements within the button inherit text color or have a compatible one */
+.btn-liquid-gold kbd {
+  color: var(--brazen-gold); /* Or a slightly less bright version if needed for contrast */
+  opacity: 0.8; /* Soften the kbd text a bit */
+}
+
 /* Shadcn base layer customizations AFTER variables are defined and AFTER @tailwind base */
 @layer base {
   * {


### PR DESCRIPTION
- Created new `.btn-liquid-gold` CSS class with specified properties including radius, height, padding, border, background, backdrop-filter, box-shadow, and text styles.
- Applied `.btn-liquid-gold` to 'Save' and 'Chat with Lune' buttons under the textarea in DiaryInput.jsx.
- Replaced the fixed bottom 'Chat with Lune' button's style with `.btn-liquid-gold` in App.js, removing the old frost container.
- Ensured layout requirements (gap, alignment, centering) are maintained.
- Removed previous violet button styling (Tailwind utilities) from the modified elements.