### PR TITLE
Refactor: Relocate 'Chat with Lune' button

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -83,6 +83,8 @@ function App() {
                   refreshEntries={refreshAllData} // Use combined refresh (now includes hashtags)
                   editingId={editingId}
                   setEditingId={setEditingId}
+                  showChat={showChat} // Pass showChat state
+                  setShowChat={setShowChat} // Pass setShowChat function
                 />
               }
             />
@@ -116,13 +118,7 @@ function App() {
         {isChatPage && (
           <footer className="w-full flex justify-center items-center px-4 pb-6"> {/* Changed pb-10 to pb-6 */}
             {/* The div with frost styling has been removed */}
-            <button
-              type="button"
-              onClick={() => setShowChat(true)} // Use setShowChat from App's state
-              className="btn-liquid-gold" // Apply the new class
-            >
-              Chat with Lune
-            </button>
+            {/* Button removed from here */}
           </footer>
         )}
         <LuneChatModal open={showChat} onClose={() => setShowChat(false)} />

--- a/lune-interface/client/src/components/DiaryInput.jsx
+++ b/lune-interface/client/src/components/DiaryInput.jsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 import { Button } from './ui/button'; // Back to relative path
 import PropTypes from 'prop-types';
 
-const DiaryInput = ({ onSave, initialText = '', clearOnSave = false }) => {
+const DiaryInput = ({ onSave, initialText = '', clearOnSave = false, onChatWithLune }) => {
   const [text, setText] = useState(initialText);
   const textareaRef = useRef(null);
 
@@ -79,6 +79,7 @@ const DiaryInput = ({ onSave, initialText = '', clearOnSave = false }) => {
         </Button>
         <Button
           className="btn-liquid-gold" // Apply the new class
+          onClick={onChatWithLune}
         >
           Chat with Lune
         </Button>
@@ -94,6 +95,12 @@ DiaryInput.propTypes = {
   onSave: PropTypes.func.isRequired,
   initialText: PropTypes.string,
   clearOnSave: PropTypes.bool,
+  onChatWithLune: PropTypes.func, // Added prop type for onChatWithLune
+};
+
+// Add default prop for onChatWithLune to avoid errors if not passed
+DiaryInput.defaultProps = {
+  onChatWithLune: () => {}, // No-op function
 };
 
 export default DiaryInput;

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -6,10 +6,10 @@ import HashtagEntriesModal from './HashtagEntriesModal'; // Import HashtagEntrie
 import DiaryInput from "./DiaryInput"; // Back to relative path
 import GoToEntriesButton from './ui/GoToEntriesButton'; // Import the new button
 
-export default function DockChat({ entries, hashtags, refreshEntries, editingId, setEditingId }) {
+export default function DockChat({ entries, hashtags, refreshEntries, editingId, setEditingId, setShowChat }) { // Added setShowChat
   const [input, setInput] = useState('');
   // const [editing, setEditing] = useState(null); // Removed internal 'editing' state
-  // const [showChat, setShowChat] = useState(false); // Moved to App.js
+  // const [showChat, setShowChat] = useState(false); // Moved to App.js - this line was already commented
   const [isHashtagModalOpen, setIsHashtagModalOpen] = useState(false); // State for hashtag modal
   const [selectedHashtag, setSelectedHashtag] = useState(null); // State for selected hashtag
 
@@ -90,7 +90,12 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
 
         {/* The form tag is kept for structure but onSubmit might need adjustment if it's meant to trigger save from DiaryInput */}
         <form onSubmit={handleSubmit} className={`flex flex-col gap-2 ${formMarginTop}`}>
-          <DiaryInput onSave={handleSave} initialText={input} clearOnSave={true} />
+          <DiaryInput
+            onSave={handleSave}
+            initialText={input}
+            clearOnSave={true}
+            onChatWithLune={() => setShowChat(true)} // Pass setShowChat to open modal
+          />
         </form>
         {/* The visual pulse line below the input might need reconsideration as DiaryInput has its own structure */}
         {/* {input.trim() && <div className="w-full h-[2px] bg-indigo-500/30 mt-1"></div>} */}
@@ -118,4 +123,5 @@ DockChat.propTypes = {
   refreshEntries: PropTypes.func.isRequired,
   editingId: PropTypes.any, // Can be null or string
   setEditingId: PropTypes.func, // Can be undefined if not passed from a route that supports editing
+  setShowChat: PropTypes.func.isRequired, // Added prop type for setShowChat
 };


### PR DESCRIPTION
- Moves the functional 'Chat with Lune' button from the footer in App.js to be next to the 'Save' button in DiaryInput.jsx.
- Removes the non-functional 'Chat with Lune' button from DiaryInput.jsx.
- Updates prop drilling to ensure the button in DiaryInput.jsx correctly opens the LuneChatModal.

Note: These changes have not been interactively tested by the user.