### PR TITLE
Fix: Ensure hashtags disappear when no diary entry references them

### DIFF
--- a/lune-interface/server/diaryStore.js
+++ b/lune-interface/server/diaryStore.js
@@ -243,9 +243,9 @@ exports.add = async function(text, folderId = null) {
 exports.getAllUniqueHashtags = async function() {
   const allHashtags = new Set();
   diary.forEach(entry => {
-    if (entry.hashtags && Array.isArray(entry.hashtags)) {
-      entry.hashtags.forEach(tag => allHashtags.add(tag));
-    }
+    // Instead of reading from entry.hashtags, parse the current text
+    const currentHashtags = parseHashtags(entry.text);
+    currentHashtags.forEach(tag => allHashtags.add(tag));
   });
   return Array.from(allHashtags).sort();
 };


### PR DESCRIPTION
Modified `getAllUniqueHashtags` in `diaryStore.js` to re-parse hashtags from the entry text each time it's called.

This ensures that the list of unique hashtags accurately reflects the current content of all diary entries, preventing orphaned hashtags from being displayed after they are removed from all entries or when entries are deleted.