### PR TITLE
Feat: Adjust vertical position of chat input module

### DIFF
--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -82,7 +82,10 @@ export default function DockChat({ entries, hashtags, refreshEntries, editingId,
     <main className="relative">
       {/* Removed opacity-0 and animate-fadeIn from the div below */}
       {/* Added flex flex-col items-center to center its children: HashtagButtons and the form */}
-      <div className="p-4 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out flex flex-col items-center">
+      <div
+        className="p-4 border-l-[1px] border-zinc-700/60 transition-opacity duration-700 ease-in-out flex flex-col items-center"
+        style={{ marginTop: '96px' }}
+      >
         <div className="flex gap-2 mb-4">
         </div>
         {/* Hashtag Buttons Area */}


### PR DESCRIPTION
Shifts the chat input block (including hashtag buttons, textarea, action buttons, and word count) downward by 96px on the /chat page.

This change is intended to improve visual balance and phase entrainment as per the design request. The margin is applied to the parent container of the hashtag buttons and the input form in DockChat.js.