### PR TITLE
feat: Implement one-time initiation view

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 // Import routing components from react-router-dom.
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 // Import custom page/view components.
+import InitiationView from './components/InitiationView'; // Import the new InitiationView
 import DockChat from './components/DockChat'; // Main chat interface component.
 import EntriesPage from './components/EntriesPage'; // Page for displaying and managing diary entries.
 import FolderViewPage from './components/FolderViewPage'; // Page for viewing entries within a specific folder.
@@ -141,14 +142,10 @@ function App() {
       <div className="flex flex-col min-h-screen">
         {/* Content area that grows to fill available space. */}
         <div className="flex-grow p-4"> {/* Added padding for visibility */}
-          {/* Example Usage of LiquidGoldButton */}
-          <div style={{ marginBottom: '20px', textAlign: 'center' }}>
-            <LiquidGoldButton onClick={() => console.log('Liquid Gold Button clicked!')}>
-              Activate Now <kbd style={{opacity: 0.7, fontSize: '0.8em', fontWeight: 'normal'}}>⌘/Ctrl&nbsp;+&nbsp;↵</kbd>
-            </LiquidGoldButton>
-          </div>
           {/* Defines the routes for the application. */}
           <Routes>
+            {/* Route for the new initiation screen. */}
+            <Route path="/start" element={<InitiationView />} />
             {/* Route for the main chat interface. */}
             <Route
               path="/chat"
@@ -193,8 +190,10 @@ function App() {
                 />
               }
             />
-            {/* Fallback route: if no other route matches, navigate to "/chat". */}
-            <Route path="*" element={<Navigate to="/chat" replace />} />
+            {/* Default route: navigate to "/start". InitiationView will handle redirect to "/chat" if already started. */}
+            <Route path="/" element={<Navigate to="/start" replace />} />
+            {/* Fallback route: if no other route matches (e.g. old bookmarks to /), navigate to "/start". */}
+            <Route path="*" element={<Navigate to="/start" replace />} />
           </Routes>
         </div>
         {/* Conditional rendering for a footer section, only shown on the chat page. */}

--- a/lune-interface/client/src/components/InitiationView.js
+++ b/lune-interface/client/src/components/InitiationView.js
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import LiquidGoldButton from './ui/LiquidGoldButton'; // Assuming path is correct
+import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts';
+
+const InitiationView = () => {
+  const navigate = useNavigate();
+  const [isFadingOut, setIsFadingOut] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (localStorage.getItem('hasStartedDiary') === 'true') {
+        navigate('/chat', { replace: true });
+      }
+    } catch (error) {
+      console.warn('localStorage is not available. Initiation screen will always show.', error);
+      // If localStorage is blocked, proceed to show the initiation screen
+    }
+  }, [navigate]);
+
+  const handleActivation = () => {
+    try {
+      localStorage.setItem('hasStartedDiary', 'true');
+    } catch (error) {
+      console.warn('localStorage is not available. Diary start will not be remembered.', error);
+      // Functionality still works, just won't remember dismissal
+    }
+    setIsFadingOut(true);
+    setTimeout(() => {
+      navigate('/chat');
+    }, 500); // Match fade-out duration
+  };
+
+  // Setup keyboard shortcut for activation
+  useKeyboardShortcuts({}, handleActivation, true);
+
+
+  const viewStyle = {
+    width: '100vw',
+    height: '100vh',
+    background: 'var(--ink-black, #000)', // Use token or fallback
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    opacity: isFadingOut ? 0 : 1,
+    transition: 'opacity 0.5s ease-out',
+  };
+
+  return (
+    <div style={viewStyle}>
+      <LiquidGoldButton onClick={handleActivation} aria-label="Activate diary">
+        Activate Now <kbd style={{opacity: 0.7, fontSize: '0.8em', fontWeight: 'normal'}}>⌘/Ctrl&nbsp;+&nbsp;↵</kbd>
+      </LiquidGoldButton>
+    </div>
+  );
+};
+
+export default InitiationView;

--- a/lune-interface/client/src/hooks/useKeyboardShortcuts.js
+++ b/lune-interface/client/src/hooks/useKeyboardShortcuts.js
@@ -2,14 +2,27 @@ import { useEffect } from 'react';
 
 /**
  * Custom hook for handling global keyboard shortcuts.
- * @param {Object} shortcuts - An object where keys are shortcut keys (e.g., 'n', 'b')
- *                             and values are callback functions to execute.
- * @param {Array<string>} targetIds - An object mapping shortcut keys to element IDs.
- *                                    Example: { n: 'add-folder-button', b: 'back-to-chat-button' }
+ * @param {Object} targetIds - An object mapping shortcut keys to element IDs for general shortcuts.
+ *                             Example: { n: 'add-folder-button', b: 'back-to-chat-button' }
+ * @param {Function} onActivate - Callback function for the special Ctrl/Cmd+Enter shortcut on initiation view.
+ * @param {boolean} isInitiationViewActive - Flag to determine if the initiation view specific shortcut should be active.
  */
-const useKeyboardShortcuts = (targetIds = {}) => {
+const useKeyboardShortcuts = (targetIds = {}, onActivate = null, isInitiationViewActive = false) => {
   useEffect(() => {
     const handleKeyDown = (event) => {
+      // Handle initiation view shortcut FIRST if active
+      if (isInitiationViewActive && onActivate && (event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+        event.preventDefault();
+        onActivate();
+        return; // Shortcut handled, no need to check others
+      }
+
+      // If initiation view shortcut was handled or not active, proceed with other shortcuts
+      // but only if not on initiation view (to prevent 'n' or 'b' from firing there)
+      if (isInitiationViewActive) {
+        return;
+      }
+
       const activeElement = document.activeElement;
       const isTyping =
         activeElement &&
@@ -50,7 +63,7 @@ const useKeyboardShortcuts = (targetIds = {}) => {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [targetIds]); // Re-run effect if targetIds change, though typically they won't.
+  }, [targetIds, onActivate, isInitiationViewActive]); // Add new dependencies
 };
 
 export default useKeyboardShortcuts;


### PR DESCRIPTION
- Adds a full-screen initiation view shown on first load.
- View contains a centered 'Activate Now' button.
- Clicking button or using Ctrl/Cmd+Enter navigates to the main diary view.
- Initiation view is skipped on subsequent loads using localStorage.
- Removes old 'Activate Now' button from main page header.
- Handles cases where localStorage might be unavailable.