### PR TITLE
feat: Implement one-time initiation screen

### DIFF
--- a/lune-interface/client/src/components/InitiationView.js
+++ b/lune-interface/client/src/components/InitiationView.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import LiquidGoldButton from './ui/LiquidGoldButton'; // Assuming path is correct
+import LiquidGoldButton from './LiquidGoldButton/LiquidGoldButton'; // Corrected path
 import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts';
 
 const InitiationView = () => {


### PR DESCRIPTION
- Verifies and finalizes the full-screen initiation view (`InitiationView.js`) that appears on the first launch.
- The view displays a centered "Activate Now" button (`LiquidGoldButton`) which, when clicked or triggered by ⌘/Ctrl + ↵, transitions you to the main diary view (`/chat`).
- Uses `localStorage` to ensure the initiation screen is shown only once. Handles cases where `localStorage` might be unavailable.
- Keyboard shortcut for activation is guarded to only be active when the initiation screen is visible.
- Corrected an import path for `LiquidGoldButton` in `InitiationView.js`.
- Confirmed that no old "Activate Now" button needed removal from the diary header as it was not present.