### PR TITLE
feat: Implement one-time initiation screen and fix ESLint errors

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'r
 // Import custom page/view components.
 import InitiationView from './components/InitiationView'; // Import the new InitiationView
 import DockChat from './components/DockChat'; // Main chat interface component.
+import LiquidGoldButton from './components/LiquidGoldButton/LiquidGoldButton'; // Import for test buttons
 import EntriesPage from './components/EntriesPage'; // Page for displaying and managing diary entries.
 import FolderViewPage from './components/FolderViewPage'; // Page for viewing entries within a specific folder.
 import LuneChatModal from './components/LuneChatModal'; // Modal component for Lune AI chat.

--- a/lune-interface/client/src/components/LiquidGoldButton/LiquidGoldButton.js
+++ b/lune-interface/client/src/components/LiquidGoldButton/LiquidGoldButton.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types'; // Import PropTypes
 import styles from './LiquidGoldButton.module.css';
 
 const LiquidGoldButton = ({ children, onClick, type = "button", className = '', ...props }) => {
@@ -12,6 +13,20 @@ const LiquidGoldButton = ({ children, onClick, type = "button", className = '', 
       </span>
     </button>
   );
+};
+
+// Define PropTypes
+LiquidGoldButton.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func.isRequired,
+  type: PropTypes.string,
+  className: PropTypes.string,
+};
+
+// Define defaultProps for non-required props that have defaults in destructuring
+LiquidGoldButton.defaultProps = {
+  type: "button",
+  className: '',
 };
 
 export default LiquidGoldButton;


### PR DESCRIPTION
- Verifies and finalizes the full-screen initiation view (`InitiationView.js`) that appears on the first launch.
- The view displays a centered "Activate Now" button (`LiquidGoldButton`) which, when clicked or triggered by ⌘/Ctrl + ↵, transitions you to the main diary view (`/chat`).
- Uses `localStorage` to ensure the initiation screen is shown only once. Handles cases where `localStorage` might be unavailable.
- Keyboard shortcut for activation is guarded to only be active when the initiation screen is visible.
- Corrected an import path for `LiquidGoldButton` in `InitiationView.js`.
- Confirmed that no old "Activate Now" button needed removal from the diary header as it was not present.

ESLint fixes:
- Imported `LiquidGoldButton` in `App.js` to resolve undefined component error for test buttons.
- Added `PropTypes` for `children`, `onClick`, `type`, and `className` in `LiquidGoldButton.js` to satisfy props validation rules.