### PR TITLE
feat: Implement one-time initiation screen and address ESLint feedback

### DIFF
--- a/lune-interface/client/src/components/LiquidGoldButton/LiquidGoldButton.js
+++ b/lune-interface/client/src/components/LiquidGoldButton/LiquidGoldButton.js
@@ -15,15 +15,19 @@ const LiquidGoldButton = ({ children, onClick, type = "button", className = '', 
   );
 };
 
-// Define PropTypes
+// Define PropTypes: Ensures children and onClick are provided, type and className are optional strings.
 LiquidGoldButton.propTypes = {
+  /** Content to be rendered inside the button */
   children: PropTypes.node.isRequired,
+  /** Function to call when the button is clicked */
   onClick: PropTypes.func.isRequired,
+  /** HTML button type attribute */
   type: PropTypes.string,
+  /** Additional CSS classes to apply to the button */
   className: PropTypes.string,
 };
 
-// Define defaultProps for non-required props that have defaults in destructuring
+// Define defaultProps: Sets default values for type and className if not provided.
 LiquidGoldButton.defaultProps = {
   type: "button",
   className: '',


### PR DESCRIPTION
- Verifies and finalizes the full-screen initiation view (`InitiationView.js`) that appears on the first launch.
- The view displays a centered "Activate Now" button (`LiquidGoldButton`) which, when clicked or triggered by ⌘/Ctrl + ↵, transitions you to the main diary view (`/chat`).
- Uses `localStorage` to ensure the initiation screen is shown only once. Handles cases where `localStorage` might be unavailable.
- Keyboard shortcut for activation is guarded to only be active when the initiation screen is visible.
- Corrected an import path for `LiquidGoldButton` in `InitiationView.js`.
- Confirmed that no old "Activate Now" button needed removal from the diary header as it was not present.

ESLint feedback actions:
- Imported `LiquidGoldButton` in `App.js` to resolve undefined component error for test buttons.
- Added/verified `PropTypes` definitions for `children`, `onClick`, `type`, and `className` in `LiquidGoldButton.js` to satisfy props validation rules. Ensured standard syntax for PropTypes declaration.