### PR TITLE
Remove unused golden buttons

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -5,7 +5,6 @@ import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'r
 // Import custom page/view components.
 import InitiationView from './components/InitiationView'; // Import the new InitiationView
 import DockChat from './components/DockChat'; // Main chat interface component.
-import LiquidGoldButton from './components/LiquidGoldButton/LiquidGoldButton'; // Import for test buttons
 import EntriesPage from './components/EntriesPage'; // Page for displaying and managing diary entries.
 import FolderViewPage from './components/FolderViewPage'; // Page for viewing entries within a specific folder.
 import LuneChatModal from './components/LuneChatModal'; // Modal component for Lune AI chat.
@@ -215,15 +214,6 @@ function App() {
           {theme === 'dark' ? '☀️' : '🌙'}
         </button>
 
-        {/* Test LiquidGoldButton */}
-        <div style={{ padding: '20px', display: 'flex', justifyContent: 'center', gap: '10px' }}>
-          <LiquidGoldButton onClick={() => alert('Liquid Gold Test Clicked!')}>
-            Test Gold Button
-          </LiquidGoldButton>
-          <LiquidGoldButton onClick={() => console.log('Another gold button clicked')}>
-            Shine On
-          </LiquidGoldButton>
-        </div>
       </div>
     );
   };


### PR DESCRIPTION
## Summary
- remove unused `LiquidGoldButton` test buttons

## Testing
- `CI=true npm test --prefix lune-interface/client --silent` *(fails: useNavigate may be used only in a Router, various test issues)*
- `npm test --prefix lune-interface/server` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68722cd3cbb08327b66b57438f595a72