### PR TITLE
Fix context menu alignment

### DIFF
--- a/lune-interface/client/src/components/HashtagContextMenu.js
+++ b/lune-interface/client/src/components/HashtagContextMenu.js
@@ -8,8 +8,8 @@ function HashtagContextMenu({ x, y, onSelect, tag }) {
 
   return (
     <div
-      className="absolute bg-zinc-700/90 backdrop-blur-sm rounded-md shadow-lg border border-zinc-500/50"
-      style={{ top: y, left: x, zIndex: 1000 }} // High z-index to appear on top
+      className="context-menu"
+      style={{ '--x': `${x}px`, '--y': `${y}px` }}
     >
       <ul className="py-1 text-white">
         <li

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -666,3 +666,16 @@ body {
     animation: shine 6s linear infinite;
   }
 }
+
+/* Context menu for hashtag actions */
+.context-menu {
+  position: absolute;
+  top: var(--y);
+  left: var(--x);
+  z-index: 1000;
+  background-color: rgba(63, 63, 70, 0.9);
+  backdrop-filter: blur(4px);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(82, 82, 91, 0.5);
+}


### PR DESCRIPTION
## Summary
- style hashtag context menu via CSS
- use CSS variables for coordinates

## Testing
- `CI=true npm test --silent --passWithNoTests` *(fails: Unable to find an element with the text: Entry 1 in Folder 1 content)*

------
https://chatgpt.com/codex/tasks/task_e_6874edf7b23c832798b9052e1a4b14c9