### PR TITLE
Remove button focus ring

### DIFF
--- a/lune-interface/client/src/components/ui/button.jsx
+++ b/lune-interface/client/src/components/ui/button.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'; // Added PropTypes
 import { cn } from "../../lib/utils" // Back to relative path
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus:outline-none disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- remove focus ring classes from `Button` component so a focus outline doesn't appear on non-input buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `cd lune-interface/server && npm test`
- `cd lune-interface/client && npm test -- -w 1` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6876473ccb3c8327bfcf1b6ff78c2814