### PR TITLE
Add tag index and TagSidebar tests

### DIFF
--- a/lune-interface/client/src/components/TagSidebar.test.js
+++ b/lune-interface/client/src/components/TagSidebar.test.js
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TagSidebar from './TagSidebar';
+
+function Wrapper() {
+  const [filter, setFilter] = useState(null);
+  const entries = [
+    { id: '1', text: 'First', tags: ['foo'] },
+    { id: '2', text: 'Second', tags: ['bar'] }
+  ];
+  const tagIndex = { foo: ['1'], bar: ['2'] };
+  const visible = filter ? entries.filter(e => e.tags.includes(filter)) : entries;
+  return (
+    <div>
+      <TagSidebar tagIndex={tagIndex} onSelect={setFilter} />
+      <ul>
+        {visible.map(e => <li key={e.id}>{e.text}</li>)}
+      </ul>
+    </div>
+  );
+}
+
+test('clicking a tag filters visible entries', () => {
+  render(<Wrapper />);
+  expect(screen.getByText('First')).toBeInTheDocument();
+  expect(screen.getByText('Second')).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /#foo \(1\)/i }));
+  expect(screen.getByText('First')).toBeInTheDocument();
+  expect(screen.queryByText('Second')).toBeNull();
+});

--- a/lune-interface/server/test/tagIndex.test.js
+++ b/lune-interface/server/test/tagIndex.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+
+const DATA_FILE = path.join(__dirname, '..', '..', '..', 'offline-diary', 'diary.json');
+let diaryStore;
+let originalData;
+
+beforeAll(() => {
+  originalData = fs.readFileSync(DATA_FILE, 'utf8');
+  diaryStore = require('../diaryStore');
+});
+
+afterAll(() => {
+  fs.writeFileSync(DATA_FILE, originalData);
+});
+
+describe('tag index updates', () => {
+  let entry1; let entry2;
+
+  test('add entries updates tag index', async () => {
+    entry1 = await diaryStore.add('First entry #foo');
+    entry2 = await diaryStore.add('Second entry #foo #bar');
+    const tags = await diaryStore.getTags();
+    expect(tags.foo).toEqual(expect.arrayContaining([entry1.id, entry2.id]));
+    expect(tags.bar).toEqual([entry2.id]);
+  });
+
+  test('update and delete entry updates tag index', async () => {
+    await diaryStore.updateText(entry1.id, 'Updated entry #baz');
+    let tags = await diaryStore.getTags();
+    expect(tags.foo).toEqual([entry2.id]);
+    expect(tags.bar).toEqual([entry2.id]);
+    expect(tags.baz).toEqual([entry1.id]);
+
+    await diaryStore.remove(entry2.id);
+    tags = await diaryStore.getTags();
+    expect(tags).toEqual({ baz: [entry1.id] });
+  });
+
+  afterAll(async () => {
+    await diaryStore.remove(entry1.id);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure tag index updates after add/update/remove operations
- test TagSidebar filtering logic in React

## Testing
- `cd lune-interface/server && npm test`
- `cd ../client && npm test -- --watchAll=false` *(fails: 5 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68778e96da1883278ae7bd8ea2e12001