### PR TITLE
Export rebuildTagIndex

### DIFF
--- a/lune-interface/server/diaryStore.js
+++ b/lune-interface/server/diaryStore.js
@@ -487,3 +487,6 @@ exports.assignEntryToFolder = async function(entryId, folderId) {
   save(); // Persist changes.
   return entry;
 };
+
+// Export the tag index rebuild function for external use
+exports.rebuildTagIndex = rebuildTagIndex;


### PR DESCRIPTION
## Summary
- expose `rebuildTagIndex` from `diaryStore`

## Testing
- `npm test --silent` in `lune-interface/server`

------
https://chatgpt.com/codex/tasks/task_e_68778e9159308327a1c7656c1759741d