### PR TITLE
Add accent purple token

### DIFF
--- a/lune-interface/client/src/styles/tokens.css
+++ b/lune-interface/client/src/styles/tokens.css
@@ -5,6 +5,7 @@
   --moon-mist: #E9E7FF;
   --brazen-gold: #F3B43F;
   --ember-red: #FF4455;
+  --accent-purple: #6848B6;
   --aqua-loop: #22D4C5;
 
   /* RGB versions for use in rgba() */


### PR DESCRIPTION
## Summary
- define `--accent-purple` in CSS tokens

## Testing
- `npm test --silent -- --watchAll=false` *(fails: unable to find accessible elements)*
- `npm test --silent` in `lune-interface/server`

------
https://chatgpt.com/codex/tasks/task_e_68778e86ce248327839029d8789d12e4