### PR TITLE
Import styles for TagSidebar

### DIFF
--- a/lune-interface/client/src/components/TagSidebar.jsx
+++ b/lune-interface/client/src/components/TagSidebar.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
+import './TagSidebar.css';
 
 function TagSidebar({ tagIndex, onSelect }) {
   const tags = Object.keys(tagIndex).sort();
@@ -10,7 +11,7 @@ function TagSidebar({ tagIndex, onSelect }) {
   }
 
   return (
-    <aside>
+    <aside className="tag-sidebar">
       <h3>Tags</h3>
       <ul>
         {tags.map(tag => (


### PR DESCRIPTION
## Summary
- style TagSidebar component by importing TagSidebar.css
- apply `tag-sidebar` class to the aside element

## Testing
- `npm test -- --watchAll=false` *(fails: Test Suites: 5 failed, 1 passed, 6 total)*

------
https://chatgpt.com/codex/tasks/task_e_68778e7948cc8327aa71e6d679f7fb1e