### PR TITLE
Add entries nav button

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation, Link } from 'react-router-dom';
 import io from 'socket.io-client';
 import InitiationView from './components/InitiationView';
 import DockChat from './components/DockChat';
@@ -245,6 +245,11 @@ function App() {
         >
           {theme === 'dark' ? '☀️' : '🌙'}
         </button>
+
+        {/* Persistent link to entries page */}
+        <Link to="/entries" className="entries-nav-button">
+          📖
+        </Link>
 
       </div>
     );

--- a/lune-interface/client/src/index.css
+++ b/lune-interface/client/src/index.css
@@ -679,3 +679,28 @@ body {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   border: 1px solid rgba(82, 82, 91, 0.5);
 }
+
+/* Floating button linking to /entries */
+.entries-nav-button {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--btn-glass-bg);
+  color: var(--btn-glass-text);
+  border: 1px solid var(--btn-glass-border);
+  box-shadow: var(--btn-glass-idle-shadow);
+  text-decoration: none;
+  font-size: 1.25rem;
+  z-index: 1000;
+  transition: filter var(--duration-fast) ease;
+}
+
+.entries-nav-button:hover {
+  filter: brightness(1.2);
+}


### PR DESCRIPTION
## Summary
- add `<Link>` to `/entries` in `App.js`
- style `.entries-nav-button` for fixed circular navigation

## Testing
- `CI=true npm test --silent` *(fails: unable to find elements and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68797578f3c483279fc42c97b781e398