### PR TITLE
Update DiaryEditable hashtag endpoint

### DIFF
--- a/lune-interface/client/src/components/DiaryEditable.js
+++ b/lune-interface/client/src/components/DiaryEditable.js
@@ -19,7 +19,7 @@ function DiaryEditable({ entry, onSave }) {
   useEffect(() => {
     const fetchHashtags = async () => {
       try {
-        const response = await fetch('/diary/hashtags');
+        const response = await fetch('/diary/tags');
         if (response.ok) {
           const data = await response.json();
           setAllHashtags(data);


### PR DESCRIPTION
## Summary
- update hashtag fetch route in DiaryEditable to `/diary/tags`

## Testing
- `npm test` *(fails: 1 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68873aeb57dc8327aac5f2d12854a9b8