### PR TITLE
Implement stub processing controller

### DIFF
--- a/lune-interface/server/controllers/processing.js
+++ b/lune-interface/server/controllers/processing.js
@@ -1,0 +1,11 @@
+module.exports.triggerAnalysis = async (req, res) => {
+  try {
+    // In a full implementation this would kick off an asynchronous analysis
+    // pipeline for a diary entry or dataset. For now it simply returns a
+    // success response so the route doesn't error when called.
+    res.json({ message: 'Analysis triggered' });
+  } catch (err) {
+    console.error('triggerAnalysis error:', err);
+    res.status(500).json({ error: 'Failed to trigger analysis' });
+  }
+};


### PR DESCRIPTION
## Summary
- add placeholder `triggerAnalysis` controller so `/api/processing/trigger` route works again
- confirm server only registers diary and lune routes

## Testing
- `npm test --silent` *(fails: Could not find migration method: up)*

------
https://chatgpt.com/codex/tasks/task_e_68873aec1ee48327abbf90aa90783d06