### PR TITLE
Refactor tag updates

### DIFF
--- a/lune-interface/server/diaryStore.js
+++ b/lune-interface/server/diaryStore.js
@@ -168,6 +168,19 @@ exports.getTags = async function({ transaction } = {}) {
 };
 
 /**
+ * @function emitTagsUpdate
+ * @description Fetches the tag index and emits a `tags-updated` event.
+ * @param {Object} io - The Socket.io server instance.
+ * @param {Object} [options] - Optional parameters.
+ * @param {Object} [options.transaction] - Sequelize transaction, if any.
+ * @returns {Promise<void>} Resolves when the event has been emitted.
+ */
+exports.emitTagsUpdate = async function(io, { transaction } = {}) {
+  const tags = await exports.getTags({ transaction });
+  io.emit('tags-updated', tags);
+};
+
+/**
  * @function findById
  * @description Finds a diary entry by its unique ID from the database.
  * @param {string} id - The unique ID of the diary entry to find.

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -27,8 +27,7 @@ module.exports = function(io) {
       }
 
       io.emit('new-entry', entry);
-      const tags = await diaryStore.getTags();
-      io.emit('tags-updated', tags);
+      await diaryStore.emitTagsUpdate(io);
 
       res.status(201).json(entry);
     } catch (err) {
@@ -63,8 +62,7 @@ router.get('/', async (req, res) => {
       }
       const entry = await diaryStore.updateText(req.params.id, text, folderId);
       io.emit('entry-updated', entry);
-      const tags = await diaryStore.getTags();
-      io.emit('tags-updated', tags);
+      await diaryStore.emitTagsUpdate(io);
 
       res.json(entry);
     } catch (err) {
@@ -102,8 +100,7 @@ router.get('/', async (req, res) => {
     try {
       await diaryStore.remove(req.params.id);
       io.emit('entry-deleted', req.params.id);
-      const tags = await diaryStore.getTags();
-      io.emit('tags-updated', tags);
+      await diaryStore.emitTagsUpdate(io);
 
       res.json({ message: 'Diary entry deleted successfully.' });
     } catch (err) {


### PR DESCRIPTION
## Summary
- centralize `tags-updated` broadcast logic in `diaryStore`
- use this helper from diary routes

## Testing
- `npm test -- -i` *(fails: Could not find migration method: up)*

------
https://chatgpt.com/codex/tasks/task_e_68873af0cd84832794c6dfdfa4630dc4