### PR TITLE
Refactor diary entry update logic

### DIFF
--- a/lune-interface/server/controllers/lune.js
+++ b/lune-interface/server/controllers/lune.js
@@ -98,7 +98,7 @@ exports.processEntry = async function(entry) {
     references: ['text', 'Resistor', 'Interpreter', 'Forge'] // Indicates sources for the reflection.
   };
   // Save the updated entry (with Lune's reflection) using diaryStore.
-  await diaryStore.saveEntry(entry);
+  await diaryStore.updateEntry({ id: entry.id, text: entry.text, folderId: entry.FolderId });
   // This function doesn't return a value, it modifies the entry and saves it.
 };
 

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -61,7 +61,7 @@ router.get('/', async (req, res) => {
       if (!text || typeof text !== 'string') {
         return res.status(400).json({ error: 'Text is required to update an entry.' });
       }
-      const entry = await diaryStore.updateText(req.params.id, text, folderId);
+      const entry = await diaryStore.updateEntry({ id: req.params.id, text, folderId });
       io.emit('entry-updated', entry);
       const tags = await diaryStore.getTags();
       io.emit('tags-updated', tags);

--- a/lune-interface/server/test/tagIndex.test.js
+++ b/lune-interface/server/test/tagIndex.test.js
@@ -54,7 +54,7 @@ describe('tag index updates', () => {
     const entry2 = await diaryStore.add('Second entry #foo #bar', null, { transaction });
 
     // Update the first entry and check if tags are updated
-    await diaryStore.updateText(entry1.id, 'Updated entry #baz', null, { transaction });
+    await diaryStore.updateEntry({ id: entry1.id, text: 'Updated entry #baz', folderId: null }, { transaction });
     let tags = await diaryStore.getTags({ transaction });
     expect(tags.foo).toEqual([entry2.id]);
     expect(tags.bar).toEqual([entry2.id]);


### PR DESCRIPTION
## Summary
- consolidate `updateText` and `saveEntry` into a single `updateEntry` function
- update diary routes and Lune controller to use `updateEntry`
- adjust tag index tests for new API

## Testing
- `npm test --silent` *(fails: Could not find migration method: up)*

------
https://chatgpt.com/codex/tasks/task_e_68873aed94408327b1bffa324b77a49f