### PR TITLE
Refactor diary update API

### DIFF
--- a/lune-interface/server/controllers/lune.js
+++ b/lune-interface/server/controllers/lune.js
@@ -98,7 +98,7 @@ exports.processEntry = async function(entry) {
     references: ['text', 'Resistor', 'Interpreter', 'Forge'] // Indicates sources for the reflection.
   };
   // Save the updated entry (with Lune's reflection) using diaryStore.
-  await diaryStore.saveEntry(entry);
+  await diaryStore.updateEntry(entry);
   // This function doesn't return a value, it modifies the entry and saves it.
 };
 

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -60,7 +60,7 @@ router.get('/', async (req, res) => {
       if (!text || typeof text !== 'string') {
         return res.status(400).json({ error: 'Text is required to update an entry.' });
       }
-      const entry = await diaryStore.updateText(req.params.id, text, folderId);
+      const entry = await diaryStore.updateEntry(req.params.id, { text, folderId });
       io.emit('entry-updated', entry);
       await diaryStore.emitTagsUpdate(io);
 

--- a/lune-interface/server/test/tagIndex.test.js
+++ b/lune-interface/server/test/tagIndex.test.js
@@ -54,7 +54,7 @@ describe('tag index updates', () => {
     const entry2 = await diaryStore.add('Second entry #foo #bar', null, { transaction });
 
     // Update the first entry and check if tags are updated
-    await diaryStore.updateText(entry1.id, 'Updated entry #baz', null, { transaction });
+    await diaryStore.updateEntry(entry1.id, { text: 'Updated entry #baz', folderId: null }, { transaction });
     let tags = await diaryStore.getTags({ transaction });
     expect(tags.foo).toEqual([entry2.id]);
     expect(tags.bar).toEqual([entry2.id]);


### PR DESCRIPTION
## Summary
- merge `updateText` and `saveEntry` into new `updateEntry`
- use the new method in diary routes and Lune controller
- adjust tag index test for new API

## Testing
- `npm test --silent` *(fails: tag index updates)*

------
https://chatgpt.com/codex/tasks/task_e_6889f90480388327a5b745245a491a87