### PR TITLE
Implement toggle for entries page button

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -246,8 +246,12 @@ function App() {
           {theme === 'dark' ? '☀️' : '🌙'}
         </button>
 
-        {/* Persistent link to entries page */}
-        <Link to="/entries" className="entries-nav-button">
+        {/* Toggle button between entries list and new entry page */}
+        <Link
+          to={location.pathname === '/entries' ? '/chat' : '/entries'}
+          className="entries-nav-button"
+          aria-label="Toggle entries view"
+        >
           📖
         </Link>
 


### PR DESCRIPTION
## Summary
- swap entries page link for a toggle
- show "entries" button returns to `/chat` when on the entries page

## Testing
- `npm test --silent --prefix lune-interface/client`

------
https://chatgpt.com/codex/tasks/task_e_688a0345cc888327b420f24d1ac338a6