### PR TITLE
Handle realtime hashtag updates

### DIFF
--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -1,13 +1,12 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation, Link } from 'react-router-dom';
-import io from 'socket.io-client';
+import socket from './lib/socket';
 import InitiationView from './components/InitiationView';
 import DockChat from './components/DockChat';
 import EntriesPage from './components/EntriesPage';
 import FolderViewPage from './components/FolderViewPage';
 import LuneChatModal from './components/LuneChatModal';
 
-const socket = io('http://localhost:5001');
 
 function App() {
   const [entries, setEntries] = useState([]);

--- a/lune-interface/client/src/lib/socket.js
+++ b/lune-interface/client/src/lib/socket.js
@@ -1,0 +1,5 @@
+import io from 'socket.io-client';
+
+const socket = io('http://localhost:5001');
+
+export default socket;


### PR DESCRIPTION
## Summary
- ensure App.js and DiaryEditable share a common Socket.io client
- transform tag index into hashtag list when fetching tags
- update hashtag suggestions when `tags-updated` socket event fires

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b4cab23b08327b546dd57f4eb4778