### PR TITLE
Add initialization hook for diary store

### DIFF
--- a/lune-interface/server/diaryStore.js
+++ b/lune-interface/server/diaryStore.js
@@ -63,10 +63,18 @@ const umzug = new Umzug({
   }
 });
 
-(async () => {
+/**
+ * @function initialize
+ * @description Runs pending migrations and migrates data from diary.json if it
+ * exists. This should be called once on server startup before handling any
+ * requests.
+ */
+async function initialize() {
   await umzug.up();
   await migrate();
-})();
+}
+
+exports.initialize = initialize;
 
 /**
  * @private

--- a/lune-interface/server/server.js
+++ b/lune-interface/server/server.js
@@ -8,6 +8,7 @@ const http = require('http');
 const { Server } = require("socket.io");
 const cors = require('cors');
 const dotenv = require('dotenv');
+const diaryStore = require('./diaryStore');
 const luneRoutes = require('./routes/lune');
 const diaryRoutes = require('./routes/diary');
 const errorMapper = require('./middleware/errorMapper');
@@ -49,9 +50,12 @@ io.on('connection', (socket) => {
 
 // Server Startup Logic
 if (require.main === module) {
-  server.listen(port, () => {
-    console.log(`Server is running on port: ${port}`);
-  });
+  (async () => {
+    await diaryStore.initialize();
+    server.listen(port, () => {
+      console.log(`Server is running on port: ${port}`);
+    });
+  })();
 }
 
 // 404 Handler


### PR DESCRIPTION
## Summary
- export an async `initialize()` from `diaryStore`
- call `diaryStore.initialize()` before starting server

## Testing
- `npm test` in `lune-interface/server`

------
https://chatgpt.com/codex/tasks/task_e_688b4caf25648327bde8a0fb9c612c05