### PR TITLE
Check fetch results in diary client

### DIFF
--- a/lune-interface/client/src/components/DiaryEditable.js
+++ b/lune-interface/client/src/components/DiaryEditable.js
@@ -131,23 +131,32 @@ function DiaryEditable({ entry, onSave }) {
     e.preventDefault();
     if (!text.trim()) return;
     try {
+      let res;
       if (entry._id) {
-        await fetch(`/diary/${entry._id}`, {
+        res = await fetch(`/diary/${entry._id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ text }),
         });
       } else {
-        await fetch('/diary', {
+        res = await fetch('/diary', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ text }),
         });
       }
+
+      if (!res.ok) {
+        const errText = await res.text();
+        console.error(errText);
+        alert(`Error saving entry: ${errText}`);
+        return;
+      }
       setText('');
       onSave && onSave();
     } catch (err) {
       console.error('Failed to save entry:', err);
+      alert(`Failed to save entry: ${err.message}`);
     }
   };
 

--- a/lune-interface/client/src/components/DiaryInput.jsx
+++ b/lune-interface/client/src/components/DiaryInput.jsx
@@ -31,12 +31,12 @@ const DiaryInput = ({ onSave, initialText = '', clearOnSave = false, onChatWithL
     setText(e.target.value);
   };
 
-  const handleKeyDown = (e) => {
+  const handleKeyDown = async (e) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
       e.preventDefault();
       if (onSave) {
-        onSave(text);
-        if (clearOnSave) {
+        const success = await onSave(text);
+        if (success && clearOnSave) {
           setText('');
         }
       }
@@ -60,10 +60,10 @@ const DiaryInput = ({ onSave, initialText = '', clearOnSave = false, onChatWithL
       <div className="flex items-center gap-4 justify-start mt-3"> {/* 1rem = gap-4, 0.75rem = mt-3 */}
         <Button
           className="btn-glass" // Apply the new class for Save button
-          onClick={() => {
+          onClick={async () => {
             if (onSave) {
-              onSave(text);
-              if (clearOnSave) {
+              const success = await onSave(text);
+              if (success && clearOnSave) {
                 setText('');
               }
             }

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -39,23 +39,31 @@ export default function DockChat({
   // Handles saving a new entry or updating an existing one.
   // This function is passed to DiaryInput component.
   const handleSave = async (text) => {
-    if (!text.trim()) return; // Do nothing if text is empty or only whitespace.
+    if (!text.trim()) return false; // Do nothing if text is empty or only whitespace.
 
     try {
+      let res;
       if (editingId) {
         // If editingId exists, update the existing entry (PUT request).
-        await fetch(`/diary/${editingId}`, {
+        res = await fetch(`/diary/${editingId}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ text })
         });
       } else {
         // If no editingId, create a new entry (POST request).
-        await fetch('/diary', {
+        res = await fetch('/diary', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ text })
         });
+      }
+
+      if (!res.ok) {
+        const errText = await res.text();
+        console.error(errText);
+        alert(`Error saving entry: ${errText}`);
+        return false;
       }
       // After successful save, reset editingId in App.js to indicate completion of edit/creation.
       if (setEditingId) {
@@ -63,9 +71,11 @@ export default function DockChat({
       }
       // The input field will be cleared by the useEffect hook above when editingId becomes null.
       await refreshEntries(); // Refresh all data to show the new/updated entry.
+      return true;
     } catch (err) {
       console.error('Failed to save entry:', err);
-      // TODO: Add user-facing error message.
+      alert(`Failed to save entry: ${err.message}`);
+      return false;
     }
   };
 

--- a/lune-interface/client/src/components/EntriesPage.js
+++ b/lune-interface/client/src/components/EntriesPage.js
@@ -27,7 +27,11 @@ export default function EntriesPage({
     // User confirmation before deleting.
     if (!window.confirm('Are you sure you want to delete this entry?')) return;
     try {
-      await fetch(`/diary/${id}`, { method: 'DELETE' }); // API call to delete the entry.
+      const res = await fetch(`/diary/${id}`, { method: 'DELETE' }); // API call to delete the entry.
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(errText || 'Failed to delete entry');
+      }
       await refreshEntries(); // Refresh all data to reflect the deletion.
     } catch (error) {
       console.error('Error deleting entry:', error);

--- a/lune-interface/client/src/components/FolderViewPage.js
+++ b/lune-interface/client/src/components/FolderViewPage.js
@@ -47,7 +47,11 @@ export default function FolderViewPage({
   const handleDeleteEntry = async (entryId) => {
     if (!window.confirm('Are you sure you want to delete this entry permanently?')) return;
     try {
-      await fetch(`/diary/${entryId}`, { method: 'DELETE' }); // API call to delete.
+      const res = await fetch(`/diary/${entryId}`, { method: 'DELETE' }); // API call to delete.
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(errText || 'Failed to delete entry');
+      }
       if (refreshEntries) {
           await refreshEntries(); // Refresh data to reflect deletion.
       }


### PR DESCRIPTION
## Summary
- check `res.ok` after saving diary entries
- keep text on error so users don't lose their input
- show alerts for failure when deleting entries

## Testing
- `bash setup.sh`
- `cd lune-interface/server && npm test` *(fails: Could not find migration method: up)*
- `cd ../client && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688b4cad02408327b33b42d83edbd39a