### PR TITLE
Fix id references in diary entry components

### DIFF
--- a/lune-interface/client/src/components/DiaryEditable.js
+++ b/lune-interface/client/src/components/DiaryEditable.js
@@ -131,8 +131,8 @@ function DiaryEditable({ entry, onSave }) {
     e.preventDefault();
     if (!text.trim()) return;
     try {
-      if (entry._id) {
-        await fetch(`/diary/${entry._id}`, {
+      if (entry.id) {
+        await fetch(`/diary/${entry.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ text }),

--- a/lune-interface/client/src/components/EntriesMenu.js
+++ b/lune-interface/client/src/components/EntriesMenu.js
@@ -31,7 +31,7 @@ function EntriesMenu({ entries, onSelect, onNew }) {
       <div className="overflow-y-auto max-h-[70vh] no-scrollbar">
         {filtered.map(entry => (
           <div
-            key={entry._id || entry.id || Math.random()}
+            key={entry.id || Math.random()}
             className="cursor-pointer p-2 rounded hover:bg-lunePurple/10 border-b"
             tabIndex={0}
             role="button"


### PR DESCRIPTION
## Summary
- update DiaryEditable to use `entry.id` when saving
- simplify key prop in EntriesMenu

## Testing
- `npm test --silent` in `lune-interface/server` *(fails: 1 failed, 10 passed)*
- `CI=true npm test --silent` in `lune-interface/client`

------
https://chatgpt.com/codex/tasks/task_e_688b4cabf0188327bd5dc5f47b452ee0