### PR TITLE
Enable async n8n webhook

### DIFF
--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -35,10 +35,16 @@ module.exports = function(io) {
       const entry = await diaryStore.add(entryText, folderId);
 
       const n8nWebhookUrl = process.env.N8N_WEBHOOK_URL;
-      try {
-        await axios.post(n8nWebhookUrl, { text: entry.text });
-      } catch (webhookError) {
-        console.error('Error sending data to n8n webhook after entry creation:', webhookError.message);
+      if (n8nWebhookUrl) {
+        // Fire and forget the webhook request so the client isn't blocked
+        axios
+          .post(n8nWebhookUrl, { text: entry.text }, { timeout: 2000 })
+          .catch((webhookError) => {
+            console.error(
+              'Error sending data to n8n webhook after entry creation:',
+              webhookError.message
+            );
+          });
       }
 
       io.emit('new-entry', serializeEntry(entry));


### PR DESCRIPTION
## Summary
- only call the webhook when `N8N_WEBHOOK_URL` is configured
- send the webhook without awaiting to avoid slowing down client responses
- log any webhook failures

## Testing
- `npm test --silent` *(fails: Cannot log after tests are done)*

------
https://chatgpt.com/codex/tasks/task_e_688b4cae60a883278c3239d592f9d836