### PR TITLE
Fix entry id references

### DIFF
--- a/lune-interface/client/src/components/DiaryEditable.js
+++ b/lune-interface/client/src/components/DiaryEditable.js
@@ -144,8 +144,8 @@ function DiaryEditable({ entry, onSave }) {
     if (!text.trim()) return;
     try {
       let res;
-      if (entry._id) {
-        res = await fetch(`/diary/${entry._id}`, {
+      if (entry.id) {
+        res = await fetch(`/diary/${entry.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ text }),

--- a/lune-interface/client/src/components/EntriesMenu.js
+++ b/lune-interface/client/src/components/EntriesMenu.js
@@ -31,7 +31,7 @@ function EntriesMenu({ entries, onSelect, onNew }) {
       <div className="overflow-y-auto max-h-[70vh] no-scrollbar">
         {filtered.map(entry => (
           <div
-            key={entry._id || entry.id || Math.random()}
+            key={entry.id || Math.random()}
             className="cursor-pointer p-2 rounded hover:bg-lunePurple/10 border-b"
             tabIndex={0}
             role="button"


### PR DESCRIPTION
## Summary
- replace `entry._id` with `entry.id` in `DiaryEditable`
- use `entry.id` consistently in `EntriesMenu`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688b4f4156c483278148d51a4c6bb31f