### PR TITLE
Add entry webhook helper

### DIFF
--- a/lune-interface/server/test/sendEntryWebhook.test.js
+++ b/lune-interface/server/test/sendEntryWebhook.test.js
@@ -1,0 +1,67 @@
+const axios = require('axios');
+const diaryRoutes = require('../routes/diary');
+const diaryStore = require('../diaryStore');
+
+jest.mock('axios');
+
+describe('sendEntryWebhook', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends payload with folder info', async () => {
+    axios.post.mockResolvedValue({});
+    jest.spyOn(diaryStore, 'findFolderById').mockResolvedValue({ id: 5, name: 'Personal' });
+    process.env.N8N_WEBHOOK_URL = 'http://example.com';
+
+    const entry = {
+      id: 1,
+      text: 'test',
+      timestamp: '2024-01-01',
+      FolderId: 5,
+      agent_logs: { Lune: { reflection: 'idea' } }
+    };
+
+    await diaryRoutes.sendEntryWebhook(entry);
+
+    expect(diaryStore.findFolderById).toHaveBeenCalledWith(5);
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://example.com',
+      {
+        entry_id: 1,
+        content: 'test',
+        created_at: '2024-01-01',
+        folder: { folder_id: 5, folder_name: 'Personal' },
+        idea: 'idea'
+      },
+      { timeout: 2000 }
+    );
+  });
+
+  it('sends payload without folder', async () => {
+    axios.post.mockResolvedValue({});
+    process.env.N8N_WEBHOOK_URL = 'http://example.com';
+
+    const entry = {
+      id: 2,
+      text: 'hello',
+      timestamp: '2024',
+      agent_logs: {}
+    };
+
+    await diaryRoutes.sendEntryWebhook(entry);
+
+    expect(diaryStore.findFolderById).not.toHaveBeenCalled();
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://example.com',
+      {
+        entry_id: 2,
+        content: 'hello',
+        created_at: '2024',
+        folder: null,
+        idea: ''
+      },
+      { timeout: 2000 }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- send diary entries to n8n via `sendEntryWebhook`
- trigger webhook after create/update/folder-change
- add unit tests for webhook helper

## Testing
- `cd lune-interface/server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688cb6cb4bf48327a5aa5bc8bc3aaa5c