### PR TITLE
Update README run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ cd lune-interface/server && npm start
 cd lune-interface/client && npm start
 ```
 
+`npm start` launches the server once. During development you can run `npm run dev` in the `lune-interface/server` directory. This uses `nodemon` to automatically restart the Express server whenever files change.
+
 Before starting the server, copy `lune-interface/server/.env.example` to
 `lune-interface/server/.env` and fill in the required values for
 `MONGO_URI`, `OPENAI_API_KEY`, `N8N_WEBHOOK_URL` and `PORT`.


### PR DESCRIPTION
## Summary
- clarify how to run the Express server in dev mode
- mention that `npm start` runs the server once

## Testing
- `npm test` (server, fails: sendEntryWebhook)
- `npm test -- --watchAll=false` (client)

------
https://chatgpt.com/codex/tasks/task_e_688ce2d731108327967e651f7cf4e70d