### PR TITLE
Ensure N8N webhook URL is configured at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ cd lune-interface/client && npm start
 
 Before starting the server, copy `lune-interface/server/.env.example` to
 `lune-interface/server/.env` and fill in the required values for
-`MONGO_URI`, `OPENAI_API_KEY`, `N8N_WEBHOOK_URL` and `PORT`.
+`MONGO_URI`, `OPENAI_API_KEY`, `N8N_WEBHOOK_URL` and `PORT`. The server
+will exit during startup if `N8N_WEBHOOK_URL` is not defined.
 
 The client is configured to proxy API requests to `http://localhost:5001`.
 To enable conversations with Lune uncomment the line enabling the route in

--- a/lune-interface/server/config/n8n.js
+++ b/lune-interface/server/config/n8n.js
@@ -1,0 +1,16 @@
+let cachedUrl;
+
+function getN8nWebhookUrl() {
+  if (cachedUrl) {
+    return cachedUrl;
+  }
+  const url = process.env.N8N_WEBHOOK_URL;
+  if (!url) {
+    console.error('N8N_WEBHOOK_URL environment variable is required but was not set.');
+    process.exit(1);
+  }
+  cachedUrl = url;
+  return cachedUrl;
+}
+
+module.exports = { getN8nWebhookUrl };

--- a/lune-interface/server/routes/diary.js
+++ b/lune-interface/server/routes/diary.js
@@ -2,13 +2,11 @@ const express = require('express');
 const diaryStore = require('../diaryStore');
 const axios = require('axios');
 const { processEntry } = require('../controllers/lune');
+const { getN8nWebhookUrl } = require('../config/n8n');
 
 // Helper to send an entry to an external n8n webhook
 async function sendEntryWebhook(entry) {
-  const webhookUrl = process.env.N8N_WEBHOOK_URL;
-  if (!webhookUrl) {
-    throw new Error('N8N_WEBHOOK_URL is not configured.');
-  }
+  const webhookUrl = getN8nWebhookUrl();
 
   let folderPayload = null;
   if (entry.FolderId) {

--- a/lune-interface/server/server.js
+++ b/lune-interface/server/server.js
@@ -8,13 +8,18 @@ const http = require('http');
 const { Server } = require("socket.io");
 const cors = require('cors');
 const dotenv = require('dotenv');
+
+// Load environment variables from .env file.
+dotenv.config();
+
 const diaryStore = require('./diaryStore');
 const luneRoutes = require('./routes/lune');
 const diaryRoutes = require('./routes/diary');
 const errorMapper = require('./middleware/errorMapper');
+const { getN8nWebhookUrl } = require('./config/n8n');
 
-// Load environment variables from .env file.
-dotenv.config();
+// Ensure required environment variables are set.
+getN8nWebhookUrl();
 
 // Initialize Express app and HTTP server.
 const app = express();


### PR DESCRIPTION
## Summary
- Add `config/n8n.js` helper to validate the `N8N_WEBHOOK_URL` environment variable
- Fail fast on server boot when the webhook URL is missing
- Document the requirement for `N8N_WEBHOOK_URL`

## Testing
- `cd lune-interface/server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f166bfd6c8327a24fe61e388b4bd4