### PR TITLE
feat: Implement Axios API layer and refactor components

### DIFF
--- a/lune-interface/client/package-lock.json
+++ b/lune-interface/client/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -5019,6 +5020,33 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14034,6 +14062,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/lune-interface/client/package.json
+++ b/lune-interface/client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/lune-interface/client/src/App.js
+++ b/lune-interface/client/src/App.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation, Link } from 'react-router-dom';
+import { getEntries, getFolders, getTagIndex } from './api/diaryApi';
 import socket from './lib/socket';
 import InitiationView from './components/InitiationView';
 import DockChat from './components/DockChat';
@@ -73,10 +74,8 @@ function App() {
   // Uses useCallback to prevent re-creation on every render unless dependencies change.
   const fetchEntries = useCallback(async () => {
     try {
-      const res = await fetch('/diary'); // API endpoint for entries.
-      if (!res.ok) throw new Error(`Failed to fetch entries: ${res.status}`);
-      const data = await res.json();
-      setEntries(data); // Update entries state with fetched data.
+      const response = await getEntries();
+      setEntries(response.data); // Update entries state with fetched data.
     } catch (error) {
       console.error("Error fetching entries:", error);
       setEntries([]); // Reset to empty array on error to prevent crashes.
@@ -86,10 +85,8 @@ function App() {
   // Callback function to fetch folders from the backend.
   const fetchFolders = useCallback(async () => {
     try {
-      const res = await fetch('/diary/folders'); // API endpoint for folders.
-      if (!res.ok) throw new Error(`Failed to fetch folders: ${res.status}`);
-      const data = await res.json();
-      setFolders(data); // Update folders state.
+      const response = await getFolders();
+      setFolders(response.data); // Update folders state.
     } catch (error) {
       console.error("Error fetching folders:", error);
       setFolders([]); // Reset on error.
@@ -98,10 +95,8 @@ function App() {
 
   const fetchTagIndex = useCallback(async () => {
     try {
-      const res = await fetch('/diary/tags');
-      if (!res.ok) throw new Error(`Failed to fetch tags: ${res.status}`);
-      const data = await res.json();
-      setTagIndex(data);
+      const response = await getTagIndex();
+      setTagIndex(response.data);
     } catch (error) {
       console.error("Error fetching tag index:", error);
       setTagIndex({});

--- a/lune-interface/client/src/api/README.md
+++ b/lune-interface/client/src/api/README.md
@@ -1,0 +1,103 @@
+# API Layer
+
+This directory contains the API layer for the application, which is built on top of Axios.
+
+## Structure
+
+-   `axiosClient.js`: The shared Axios instance. It includes interceptors for logging, error handling, and retries.
+-   `diaryApi.js`: API functions related to diary entries, folders, and tags.
+-   `luneApi.js`: API functions related to the Lune AI service.
+-   `errors.js`: Custom error classes for the API layer.
+-   `cancellation.js`: Helper function for request cancellation.
+
+## Usage
+
+### `axiosClient`
+
+The `axiosClient` is a pre-configured Axios instance that can be used to make direct API calls. It includes:
+
+-   A base URL configured from environment variables.
+-   A 10-second timeout.
+-   Interceptors for logging requests and responses.
+-   Error handling for common HTTP status codes (401, 403, 429).
+-   A retry mechanism for idempotent requests that fail with a 5xx error.
+
+### API Functions
+
+The `diaryApi.js` and `luneApi.js` files export functions for all the API calls in the application. These functions return a promise that resolves with the Axios response object.
+
+**Example: Get all diary entries**
+
+```javascript
+import { getEntries } from './diaryApi';
+
+async function fetchEntries() {
+  try {
+    const response = await getEntries();
+    console.log(response.data);
+  } catch (error) {
+    console.error(error);
+  }
+}
+```
+
+### Error Handling
+
+The API layer uses custom error classes defined in `errors.js`:
+
+-   `ApiError`: For errors returned by the API (e.g., 4xx or 5xx status codes).
+-   `NetworkError`: For network errors (e.g., no response from the server).
+-   `CancelledError`: For when a request is cancelled.
+
+You can use these error classes to handle different types of errors gracefully.
+
+**Example: Error handling**
+
+```javascript
+import { getEntries } from './diaryApi';
+import { ApiError, NetworkError } from './errors';
+
+async function fetchEntries() {
+  try {
+    const response = await getEntries();
+    console.log(response.data);
+  } catch (error) {
+    if (error instanceof ApiError) {
+      console.error(`API Error: ${error.message}, Status: ${error.status}`);
+    } else if (error instanceof NetworkError) {
+      console.error(`Network Error: ${error.message}`);
+    } else {
+      console.error(`An unexpected error occurred: ${error.message}`);
+    }
+  }
+}
+```
+
+### Request Cancellation
+
+All API functions support request cancellation using an `AbortController`.
+
+**Example: Request cancellation**
+
+```javascript
+import { getEntries } from './diaryApi';
+import { getCancelToken } from './cancellation';
+
+const controller = getCancelToken();
+
+async function fetchEntries() {
+  try {
+    const response = await getEntries({ signal: controller.signal });
+    console.log(response.data);
+  } catch (error) {
+    if (error.name === 'CancelledError') {
+      console.log('Request was cancelled');
+    } else {
+      console.error(error);
+    }
+  }
+}
+
+// To cancel the request:
+// controller.abort();
+```

--- a/lune-interface/client/src/api/__tests__/diaryApi.test.js
+++ b/lune-interface/client/src/api/__tests__/diaryApi.test.js
@@ -1,0 +1,118 @@
+import axiosClient from '../axiosClient';
+import {
+  getEntries,
+  getFolders,
+  getTagIndex,
+  createEntry,
+  updateEntry,
+  deleteEntry,
+  createFolder,
+  updateEntryFolder,
+} from '../diaryApi';
+
+jest.mock('../axiosClient');
+
+describe('diaryApi', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getEntries', () => {
+    it('should call axiosClient.get with the correct URL', async () => {
+      const mockData = { data: [{ id: 1, text: 'Test Entry' }] };
+      axiosClient.get.mockResolvedValue(mockData);
+
+      const result = await getEntries();
+
+      expect(axiosClient.get).toHaveBeenCalledWith('/diary', { signal: undefined });
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('getFolders', () => {
+    it('should call axiosClient.get with the correct URL', async () => {
+      const mockData = { data: [{ id: 1, name: 'Test Folder' }] };
+      axiosClient.get.mockResolvedValue(mockData);
+
+      const result = await getFolders();
+
+      expect(axiosClient.get).toHaveBeenCalledWith('/diary/folders', { signal: undefined });
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('getTagIndex', () => {
+    it('should call axiosClient.get with the correct URL', async () => {
+      const mockData = { data: { test: 1 } };
+      axiosClient.get.mockResolvedValue(mockData);
+
+      const result = await getTagIndex();
+
+      expect(axiosClient.get).toHaveBeenCalledWith('/diary/tags', { signal: undefined });
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('createEntry', () => {
+    it('should call axiosClient.post with the correct URL and data', async () => {
+      const mockData = { data: { id: 1, text: 'New Entry' } };
+      const newEntry = { text: 'New Entry' };
+      axiosClient.post.mockResolvedValue(mockData);
+
+      const result = await createEntry(newEntry);
+
+      expect(axiosClient.post).toHaveBeenCalledWith('/diary', newEntry, { signal: undefined });
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('updateEntry', () => {
+    it('should call axiosClient.put with the correct URL and data', async () => {
+      const mockData = { data: { id: 1, text: 'Updated Entry' } };
+      const updatedEntry = { text: 'Updated Entry' };
+      axiosClient.put.mockResolvedValue(mockData);
+
+      const result = await updateEntry(1, updatedEntry);
+
+      expect(axiosClient.put).toHaveBeenCalledWith('/diary/1', updatedEntry, { signal: undefined });
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('deleteEntry', () => {
+    it('should call axiosClient.delete with the correct URL', async () => {
+      const mockData = { data: {} };
+      axiosClient.delete.mockResolvedValue(mockData);
+
+      const result = await deleteEntry(1);
+
+      expect(axiosClient.delete).toHaveBeenCalledWith('/diary/1', { signal: undefined });
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('createFolder', () => {
+    it('should call axiosClient.post with the correct URL and data', async () => {
+        const mockData = { data: { id: 1, name: 'New Folder' } };
+        const newFolder = { name: 'New Folder' };
+        axiosClient.post.mockResolvedValue(mockData);
+
+        const result = await createFolder(newFolder);
+
+        expect(axiosClient.post).toHaveBeenCalledWith('/diary/folders', newFolder, { signal: undefined });
+        expect(result).toEqual(mockData);
+    });
+  });
+
+    describe('updateEntryFolder', () => {
+        it('should call axiosClient.post with the correct URL and data', async () => {
+            const mockData = { data: {} };
+            axiosClient.post.mockResolvedValue(mockData);
+
+            const result = await updateEntryFolder(1, 2);
+
+            expect(axiosClient.post).toHaveBeenCalledWith('/diary/1/folder', { folderId: 2 }, { signal: undefined });
+            expect(result).toEqual(mockData);
+        });
+    });
+});

--- a/lune-interface/client/src/api/__tests__/luneApi.test.js
+++ b/lune-interface/client/src/api/__tests__/luneApi.test.js
@@ -1,0 +1,36 @@
+import axiosClient from '../axiosClient';
+import { logToLune, sendToLune } from '../luneApi';
+
+jest.mock('../axiosClient');
+
+describe('luneApi', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('logToLune', () => {
+        it('should call axiosClient.post with the correct URL and data', async () => {
+            const mockData = { data: {} };
+            const conversation = [{ sender: 'user', text: 'hello' }];
+            axiosClient.post.mockResolvedValue(mockData);
+
+            const result = await logToLune({ conversation });
+
+            expect(axiosClient.post).toHaveBeenCalledWith('/api/lune/log', { conversation }, { signal: undefined });
+            expect(result).toEqual(mockData);
+        });
+    });
+
+    describe('sendToLune', () => {
+        it('should call axiosClient.post with the correct URL and data', async () => {
+            const mockData = { data: { aiReply: 'hello there' } };
+            const message = { sessionId: '123', userMessage: 'hello' };
+            axiosClient.post.mockResolvedValue(mockData);
+
+            const result = await sendToLune(message);
+
+            expect(axiosClient.post).toHaveBeenCalledWith('/api/lune/send', message, { signal: undefined });
+            expect(result).toEqual(mockData);
+        });
+    });
+});

--- a/lune-interface/client/src/api/axiosClient.js
+++ b/lune-interface/client/src/api/axiosClient.js
@@ -1,0 +1,83 @@
+import axios from 'axios';
+import { ApiError, NetworkError, CancelledError } from './errors';
+
+const axiosClient = axios.create({
+  baseURL: process.env.REACT_APP_API_BASE_URL,
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json'
+  }
+});
+
+// Request interceptor for logging and auth
+axiosClient.interceptors.request.use(
+  (config) => {
+    // In a real app, you would get the token from local storage or a state manager
+    // const token = localStorage.getItem('token');
+    // if (token) {
+    //   config.headers.Authorization = `Bearer ${token}`;
+    // }
+    console.log('Starting Request', config);
+    return config;
+  },
+  (error) => {
+    console.error('Request Error', error);
+    return Promise.reject(new NetworkError(error.message));
+  }
+);
+
+// Response interceptor for logging, error handling, and retries
+axiosClient.interceptors.response.use(
+  (response) => {
+    console.log('Response:', response);
+    return response;
+  },
+  (error) => {
+    console.error('Response Error', error);
+
+    if (axios.isCancel(error)) {
+      return Promise.reject(new CancelledError());
+    }
+
+    const { config, response } = error;
+    const originalRequest = config;
+
+    // Retry logic for idempotent methods
+    const idempotentMethods = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'];
+    if (response && response.status >= 500 && idempotentMethods.includes(originalRequest.method.toUpperCase()) && (!originalRequest._retry || originalRequest._retry < 3)) {
+      originalRequest._retry = (originalRequest._retry || 0) + 1;
+      const delay = 1000 * originalRequest._retry;
+      console.log(`Retrying request, attempt ${originalRequest._retry}, delay ${delay}ms`);
+      return new Promise((resolve) => setTimeout(() => resolve(axiosClient(originalRequest)), delay));
+    }
+
+
+    if (response) {
+      const { status, data } = response;
+      const message = (data && data.message) ? data.message : 'An error occurred';
+
+      if (status === 401) {
+        // In a real app, you might redirect to a login page
+        console.error('Unauthorized. Redirecting to login...');
+        // window.location.href = '/login';
+      }
+
+      if (status === 403) {
+        console.error('Forbidden. You do not have permission to access this resource.');
+      }
+
+      if (status === 429) {
+        console.error('Too many requests. Please try again later.');
+      }
+
+      return Promise.reject(new ApiError(message, status));
+    } else if (error.request) {
+      return Promise.reject(new NetworkError('No response received from server.'));
+    } else {
+      return Promise.reject(new Error(error.message));
+    }
+  }
+);
+
+export default axiosClient;

--- a/lune-interface/client/src/api/cancellation.js
+++ b/lune-interface/client/src/api/cancellation.js
@@ -1,0 +1,3 @@
+export function getCancelToken() {
+  return new AbortController();
+}

--- a/lune-interface/client/src/api/diaryApi.js
+++ b/lune-interface/client/src/api/diaryApi.js
@@ -1,0 +1,33 @@
+import axiosClient from './axiosClient';
+
+export const getEntries = ({ signal } = {}) => {
+  return axiosClient.get('/diary', { signal });
+};
+
+export const getFolders = ({ signal } = {}) => {
+  return axiosClient.get('/diary/folders', { signal });
+};
+
+export const getTagIndex = ({ signal } = {}) => {
+  return axiosClient.get('/diary/tags', { signal });
+};
+
+export const createEntry = (data, { signal } = {}) => {
+  return axiosClient.post('/diary', data, { signal });
+};
+
+export const updateEntry = (id, data, { signal } = {}) => {
+  return axiosClient.put(`/diary/${id}`, data, { signal });
+};
+
+export const deleteEntry = (id, { signal } = {}) => {
+  return axiosClient.delete(`/diary/${id}`, { signal });
+};
+
+export const createFolder = (data, { signal } = {}) => {
+  return axiosClient.post('/diary/folders', data, { signal });
+};
+
+export const updateEntryFolder = (entryId, folderId, { signal } = {}) => {
+  return axiosClient.post(`/diary/${entryId}/folder`, { folderId }, { signal });
+};

--- a/lune-interface/client/src/api/errors.js
+++ b/lune-interface/client/src/api/errors.js
@@ -1,0 +1,21 @@
+export class NetworkError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'NetworkError';
+  }
+}
+
+export class ApiError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+export class CancelledError extends Error {
+  constructor(message = 'Request was cancelled') {
+    super(message);
+    this.name = 'CancelledError';
+  }
+}

--- a/lune-interface/client/src/api/luneApi.js
+++ b/lune-interface/client/src/api/luneApi.js
@@ -1,0 +1,9 @@
+import axiosClient from './axiosClient';
+
+export const logToLune = (data, { signal } = {}) => {
+  return axiosClient.post('/api/lune/log', data, { signal });
+};
+
+export const sendToLune = (data, { signal } = {}) => {
+  return axiosClient.post('/api/lune/send', data, { signal });
+};

--- a/lune-interface/client/src/components/DockChat.js
+++ b/lune-interface/client/src/components/DockChat.js
@@ -1,6 +1,7 @@
 // Import React hooks and PropTypes for type checking.
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { createEntry, updateEntry } from '../api/diaryApi';
 // Import sub-components used within DockChat.
 import TagSidebar from './TagSidebar';
 import DiaryInput from "./DiaryInput"; // The main text input component for diary entries.
@@ -42,29 +43,14 @@ export default function DockChat({
     if (!text.trim()) return false; // Do nothing if text is empty or only whitespace.
 
     try {
-      let res;
       if (editingId) {
         // If editingId exists, update the existing entry (PUT request).
-        res = await fetch(`/diary/${editingId}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ text })
-        });
+        await updateEntry(editingId, { text });
       } else {
         // If no editingId, create a new entry (POST request).
-        res = await fetch('/diary', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ text })
-        });
+        await createEntry({ text });
       }
 
-      if (!res.ok) {
-        const errText = await res.text();
-        console.error(errText);
-        alert(`Error saving entry: ${errText}`);
-        return false;
-      }
       // After successful save, reset editingId in App.js to indicate completion of edit/creation.
       if (setEditingId) {
         setEditingId(null);

--- a/lune-interface/client/src/components/FolderViewPage.js
+++ b/lune-interface/client/src/components/FolderViewPage.js
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useParams, useNavigate, Link } from 'react-router-dom';
+import { deleteEntry, updateEntryFolder } from '../api/diaryApi';
 // Import CSS module for component-specific styling.
 import styles from './FolderViewPage.module.css';
 // Import UI component for displaying entries.
@@ -47,11 +48,7 @@ export default function FolderViewPage({
   const handleDeleteEntry = async (entryId) => {
     if (!window.confirm('Are you sure you want to delete this entry permanently?')) return;
     try {
-      const res = await fetch(`/diary/${entryId}`, { method: 'DELETE' }); // API call to delete.
-      if (!res.ok) {
-        const errText = await res.text();
-        throw new Error(errText || 'Failed to delete entry');
-      }
+      await deleteEntry(entryId);
       if (refreshEntries) {
           await refreshEntries(); // Refresh data to reflect deletion.
       }
@@ -65,15 +62,7 @@ export default function FolderViewPage({
   const handleRemoveEntryFromFolder = async (entryId) => {
     if (!window.confirm('Are you sure you want to remove this entry from the folder?')) return;
     try {
-      const response = await fetch(`/diary/${entryId}/folder`, { // API call to update folderId.
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ folderId: null }), // Set folderId to null.
-      });
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to remove entry from folder');
-      }
+      await updateEntryFolder(entryId, null);
       if (refreshEntries) {
         await refreshEntries(); // Refresh data; the entry will no longer appear in this folder.
       }


### PR DESCRIPTION
This commit introduces a new Axios-based API layer to handle all API communications.

The new API layer includes:
- A shared Axios client with interceptors for logging, error handling, and retries.
- Centralized API functions for diary and lune services.
- Custom error classes for better error handling.
- Support for request cancellation.

All components have been refactored to use the new API layer instead of `fetch`.

Unit tests have been added for the new API functions. Documentation for the new API layer has been added.