### PR TITLE
chore: add Jest configuration for client tests

### DIFF
--- a/lune-interface/client/jest.config.js
+++ b/lune-interface/client/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  rootDir: './',
+  testMatch: ['<rootDir>/src/**/__tests__/**/*.test.js']
+};


### PR DESCRIPTION
## Summary
- add Jest config to locate test files under `src/**/__tests__/**/*.test.js`

## Testing
- `npm test --watchAll=false` *(fails: SyntaxError Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6895d59ae31083278392d29eaf75cfc4